### PR TITLE
Slice 2: project registry — register, list, view, delete

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,6 +15,9 @@
     ".output",
     ".nitro",
     ".tanstack",
+    ".agents",
+    ".claude",
+    ".cursor",
     "dist",
     "src/routeTree.gen.ts"
   ]

--- a/README.md
+++ b/README.md
@@ -57,24 +57,27 @@ All configuration is via environment variables. There is no config file in v1.
 
 | Variable                 | Default                | Description                                                    |
 | ------------------------ | ---------------------- | -------------------------------------------------------------- |
-| `PORT`                   | `2633`                 | Port the HTTP server listens on.                               |
+| `PORT`                   | `2633`                 | Port the HTTP server listens on (web in dev; everything in prod). |
+| `API_PORT`               | `2634`                 | Dev-only API port that Vite proxies `/api/*` to.               |
 | `HOST`                   | `127.0.0.1`            | Bind address. Set to `0.0.0.0` to expose on the LAN/Tailscale. |
 | `CLAUDE_REMOTE_DATA_DIR` | `~/.claude-remote`     | Directory for SQLite cache and any runtime state.              |
 | `CLAUDE_REMOTE_DB_PATH`  | `<DATA_DIR>/db.sqlite` | Override the SQLite file location directly.                    |
 
 ## Scripts
 
-| Script               | Description                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| `bun run dev`        | Migrate, then run the dev server (Vite + TanStack Start).    |
-| `bun run build`      | Build the client + SSR bundles for production.               |
-| `bun run start`      | Run the production server (Bun.serve over the built output). |
-| `bun run db:migrate` | Apply pending SQL migrations.                                |
-| `bun run test`       | Run Vitest.                                                  |
-| `bun run test:watch` | Run Vitest in watch mode.                                    |
-| `bun run lint`       | Lint with oxlint.                                            |
-| `bun run format`     | Format with oxfmt.                                           |
-| `bun run typecheck`  | Type-check with tsgo.                                        |
+| Script               | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| `bun run dev`        | Migrate, then run Vite (web) + a Bun API process side-by-side; Vite proxies `/api/*` to the API. |
+| `bun run dev:api`    | Run only the Bun API process (`server/dev-api.ts`) with `--hot`.            |
+| `bun run dev:web`    | Run only `vite dev` for the front-end.                                      |
+| `bun run build`      | Build the client + SSR bundles for production.                              |
+| `bun run start`      | Run the production server (single `Bun.serve` over the built output, including the API). |
+| `bun run db:migrate` | Apply pending SQL migrations.                                               |
+| `bun run test`       | Run Vitest.                                                                 |
+| `bun run test:watch` | Run Vitest in watch mode.                                                   |
+| `bun run lint`       | Lint with oxlint.                                                           |
+| `bun run format`     | Format with oxfmt.                                                          |
+| `bun run typecheck`  | Type-check with tsgo.                                                       |
 
 ## Database & migrations
 
@@ -87,12 +90,23 @@ SQLite, opened via `bun:sqlite`. Schema evolves through numbered SQL files in `s
 
 The runner has unit tests in `tests/migrator.test.ts`. Run them with `bun run test`.
 
+## HTTP API
+
+| Method   | Path                  | Description                                                                                        |
+| -------- | --------------------- | -------------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/projects`       | List all registered projects.                                                                      |
+| `POST`   | `/api/projects`       | Register `{ name, repo_path }`. Validates the path is a git repo and detects the default branch.  |
+| `GET`    | `/api/projects/:id`   | Get a single project.                                                                              |
+| `DELETE` | `/api/projects/:id`   | Remove the registry row. **Does not** touch the filesystem at `repo_path`.                         |
+
+Validation errors return `400` (`409` for re-registering the same path) with `{ error: { code, field?, message } }`.
+
 ## A note on Vite
 
 `CLAUDE.md` in this repo says "don't use Vite, use `Bun.serve()`." This project is the documented exception: TanStack Start is built on Vite, and we take Vite as a build tool to get TanStack Start's framework value (file-based routing, server functions, type-safe data loading, SSR). At runtime everything still runs on Bun:
 
-- **Dev:** `vite dev` is invoked through Bun (`bun --bun x vite dev`), so the dev server process is a Bun process.
-- **Prod:** `vite build` produces a `{ fetch }`-style SSR bundle in `dist/server/server.js` plus static assets in `dist/client/`. The `bun run start` entry (`index.ts`) wraps that bundle in `Bun.serve()`, so the production server is a single Bun process that owns HTTP, the SQLite cache, and (in later slices) the WebSocket transport and Claude Agent SDK processes.
+- **Dev:** `bun run dev` launches two Bun processes: one runs `vite dev` for the web (HMR, TanStack Start) and one runs `server/dev-api.ts` (`Bun.serve` + `bun:sqlite`). Vite proxies `/api/*` to the API process so the front-end can call the real API in development. The split exists because Vite itself runs under Node, which can't import `bun:sqlite`.
+- **Prod:** `vite build` produces a `{ fetch }`-style SSR bundle in `dist/server/server.js` plus static assets in `dist/client/`. The `bun run start` entry (`index.ts`) wraps that bundle in a single `Bun.serve()` that owns the API, the SQLite cache, static assets, and SSR — and (in later slices) the WebSocket transport and Claude Agent SDK processes.
 
 This exception applies only to TanStack Start. New runtime code in this repo continues to use `Bun.serve()`, `bun:sqlite`, `Bun.file`, etc., per `CLAUDE.md`.
 

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { stat } from "node:fs/promises";
 import { loadConfig } from "./server/config.ts";
 import { openDatabase } from "./server/db/client.ts";
 import { runMigrationsFromDir } from "./server/db/migrator.ts";
+import { handleApi } from "./server/api/handler.ts";
 
 const ROOT = import.meta.dir;
 const MIGRATIONS_DIR = resolve(ROOT, "server/db/migrations");
@@ -12,13 +13,9 @@ const SERVER_ENTRY = resolve(ROOT, "dist/server/server.js");
 const config = loadConfig();
 
 const db = openDatabase(config.dbPath);
-try {
-  const result = runMigrationsFromDir(db, MIGRATIONS_DIR);
-  if (result.applied.length > 0) {
-    console.log(`[db] applied ${result.applied.length} migration(s) on startup`);
-  }
-} finally {
-  db.close();
+const result = runMigrationsFromDir(db, MIGRATIONS_DIR);
+if (result.applied.length > 0) {
+  console.log(`[db] applied ${result.applied.length} migration(s) on startup`);
 }
 
 const ssr = (await import(SERVER_ENTRY)) as {
@@ -40,6 +37,9 @@ const server = Bun.serve({
   hostname: config.host,
   idleTimeout: 30,
   async fetch(req) {
+    const apiResponse = await handleApi(req, { db });
+    if (apiResponse) return apiResponse;
+
     const url = new URL(req.url);
     const asset = await serveStatic(url.pathname);
     if (asset) return asset;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   },
   "scripts": {
     "predev": "bun run db:migrate",
-    "dev": "vite dev",
+    "dev": "bun ./scripts/dev.ts",
+    "dev:api": "bun --hot ./server/dev-api.ts",
+    "dev:web": "bunx --bun vite dev",
     "build": "vite build",
     "start": "bun ./index.ts",
     "db:migrate": "bun ./server/db/migrate.ts",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,33 @@
+import { spawn, type Subprocess } from "bun";
+
+const apiPort = process.env.API_PORT ?? "2634";
+
+const children: Subprocess[] = [
+  spawn(["bun", "--hot", "./server/dev-api.ts"], {
+    stdout: "inherit",
+    stderr: "inherit",
+    env: { ...process.env, API_PORT: apiPort },
+  }),
+  spawn(["bunx", "--bun", "vite", "dev"], {
+    stdout: "inherit",
+    stderr: "inherit",
+    env: { ...process.env, API_PORT: apiPort },
+  }),
+];
+
+let shuttingDown = false;
+function shutdown(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of children) {
+    if (!child.killed) child.kill();
+  }
+  process.exit(code);
+}
+
+process.on("SIGINT", () => shutdown(130));
+process.on("SIGTERM", () => shutdown(143));
+
+const exits = children.map((child) => child.exited);
+const exitCode = await Promise.race(exits);
+shutdown(typeof exitCode === "number" ? exitCode : 0);

--- a/server/api/handler.ts
+++ b/server/api/handler.ts
@@ -1,0 +1,116 @@
+import type { Database } from "bun:sqlite";
+import {
+  deleteProject,
+  getProject,
+  listProjects,
+  ProjectValidationError,
+  registerProject,
+  type Project,
+} from "../projects/registry.ts";
+
+export type ApiContext = {
+  db: Database;
+};
+
+const json = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+
+function projectsListUrl(pathname: string): boolean {
+  return pathname === "/api/projects" || pathname === "/api/projects/";
+}
+
+function projectByIdMatch(pathname: string): string | null {
+  const m = /^\/api\/projects\/([^/]+)\/?$/.exec(pathname);
+  return m ? decodeURIComponent(m[1]!) : null;
+}
+
+async function readJson(req: Request): Promise<unknown> {
+  try {
+    return await req.json();
+  } catch {
+    return null;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function handleCreateProject(req: Request, ctx: ApiContext): Promise<Response> {
+  const body = await readJson(req);
+  if (!isPlainObject(body)) {
+    return json(400, {
+      error: { code: "invalid_body", message: "Request body must be a JSON object" },
+    });
+  }
+
+  const name = typeof body.name === "string" ? body.name : "";
+  const repoPath = typeof body.repo_path === "string" ? body.repo_path : "";
+
+  try {
+    const project = await registerProject(ctx.db, { name, repo_path: repoPath });
+    return json(201, project);
+  } catch (err) {
+    if (err instanceof ProjectValidationError) {
+      const status = err.code === "already_registered" ? 409 : 400;
+      return json(status, {
+        error: { code: err.code, field: err.field, message: err.message },
+      });
+    }
+    throw err;
+  }
+}
+
+function handleListProjects(ctx: ApiContext): Response {
+  const projects: Project[] = listProjects(ctx.db);
+  return json(200, { projects });
+}
+
+function handleGetProject(id: string, ctx: ApiContext): Response {
+  const project = getProject(ctx.db, id);
+  if (!project) {
+    return json(404, { error: { code: "not_found", message: `No project with id "${id}"` } });
+  }
+  return json(200, project);
+}
+
+function handleDeleteProject(id: string, ctx: ApiContext): Response {
+  const removed = deleteProject(ctx.db, id);
+  if (!removed) {
+    return json(404, { error: { code: "not_found", message: `No project with id "${id}"` } });
+  }
+  return new Response(null, { status: 204 });
+}
+
+export async function handleApi(req: Request, ctx: ApiContext): Promise<Response | null> {
+  const url = new URL(req.url);
+  if (!url.pathname.startsWith("/api/")) return null;
+
+  if (projectsListUrl(url.pathname)) {
+    if (req.method === "GET") return handleListProjects(ctx);
+    if (req.method === "POST") return handleCreateProject(req, ctx);
+    return json(405, {
+      error: {
+        code: "method_not_allowed",
+        message: `Method ${req.method} not allowed on ${url.pathname}`,
+      },
+    });
+  }
+
+  const id = projectByIdMatch(url.pathname);
+  if (id) {
+    if (req.method === "GET") return handleGetProject(id, ctx);
+    if (req.method === "DELETE") return handleDeleteProject(id, ctx);
+    return json(405, {
+      error: {
+        code: "method_not_allowed",
+        message: `Method ${req.method} not allowed on ${url.pathname}`,
+      },
+    });
+  }
+
+  return json(404, { error: { code: "not_found", message: `Unknown API route: ${url.pathname}` } });
+}

--- a/server/dev-api.ts
+++ b/server/dev-api.ts
@@ -1,0 +1,34 @@
+import { resolve } from "node:path";
+import { loadConfig } from "./config.ts";
+import { openDatabase } from "./db/client.ts";
+import { runMigrationsFromDir } from "./db/migrator.ts";
+import { handleApi } from "./api/handler.ts";
+
+const ROOT = resolve(import.meta.dir, "..");
+const MIGRATIONS_DIR = resolve(ROOT, "server/db/migrations");
+
+const config = loadConfig();
+const db = openDatabase(config.dbPath);
+const result = runMigrationsFromDir(db, MIGRATIONS_DIR);
+if (result.applied.length > 0) {
+  console.log(`[dev-api] applied ${result.applied.length} migration(s) on startup`);
+}
+
+const apiPortValue = process.env.API_PORT ?? "2634";
+const apiPort = Number.parseInt(apiPortValue, 10);
+if (!Number.isInteger(apiPort) || apiPort <= 0 || apiPort > 65535) {
+  throw new Error(`Invalid API_PORT="${apiPortValue}"`);
+}
+
+const server = Bun.serve({
+  port: apiPort,
+  hostname: config.host,
+  idleTimeout: 30,
+  async fetch(req) {
+    const response = await handleApi(req, { db });
+    if (response) return response;
+    return new Response("Not Found", { status: 404 });
+  },
+});
+
+console.log(`[dev-api] serving on http://${server.hostname}:${server.port} (db: ${config.dbPath})`);

--- a/server/git.ts
+++ b/server/git.ts
@@ -1,0 +1,67 @@
+import { resolve } from "node:path";
+import { realpath, stat } from "node:fs/promises";
+import { $ } from "bun";
+
+export class NotAGitRepoError extends Error {
+  readonly path: string;
+  constructor(path: string, reason: string) {
+    super(`"${path}" is not a git repository: ${reason}`);
+    this.name = "NotAGitRepoError";
+    this.path = path;
+  }
+}
+
+async function pathIsDirectory(path: string): Promise<boolean> {
+  const info = await stat(path).catch(() => null);
+  return info?.isDirectory() ?? false;
+}
+
+export async function assertGitRepo(repoPath: string): Promise<string> {
+  const absolute = resolve(repoPath);
+
+  if (!(await pathIsDirectory(absolute))) {
+    throw new NotAGitRepoError(absolute, "path does not exist or is not a directory");
+  }
+
+  // git's --show-toplevel reports the canonical (symlink-resolved) path, so
+  // compare against realpath to avoid false negatives on systems where the
+  // input path traverses symlinks (e.g. macOS /var → /private/var).
+  const canonical = await realpath(absolute);
+
+  const result = await $`git -C ${canonical} rev-parse --show-toplevel`.quiet().nothrow();
+  if (result.exitCode !== 0) {
+    throw new NotAGitRepoError(absolute, "git rev-parse reported no working tree at this path");
+  }
+
+  const toplevel = result.stdout.toString().trim();
+  if (toplevel !== canonical) {
+    throw new NotAGitRepoError(
+      absolute,
+      `path is inside a git repo but not its root (root is "${toplevel}")`,
+    );
+  }
+
+  return canonical;
+}
+
+export async function detectDefaultBranch(repoPath: string): Promise<string> {
+  const absolute = resolve(repoPath);
+
+  const remoteHead = await $`git -C ${absolute} symbolic-ref --short refs/remotes/origin/HEAD`
+    .quiet()
+    .nothrow();
+  if (remoteHead.exitCode === 0) {
+    const ref = remoteHead.stdout.toString().trim();
+    const slash = ref.indexOf("/");
+    if (slash >= 0) return ref.slice(slash + 1);
+    if (ref.length > 0) return ref;
+  }
+
+  const current = await $`git -C ${absolute} branch --show-current`.quiet().nothrow();
+  if (current.exitCode === 0) {
+    const branch = current.stdout.toString().trim();
+    if (branch.length > 0) return branch;
+  }
+
+  return "main";
+}

--- a/server/projects/registry.ts
+++ b/server/projects/registry.ts
@@ -1,0 +1,146 @@
+import { basename, dirname, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { Database } from "bun:sqlite";
+import { assertGitRepo, detectDefaultBranch, NotAGitRepoError } from "../git.ts";
+
+export type PermissionsMode = "bypassPermissions" | "acceptEdits";
+
+export type Project = {
+  id: string;
+  name: string;
+  repo_path: string;
+  default_branch: string;
+  worktree_root: string;
+  permissions_mode: PermissionsMode;
+  created_at: string;
+};
+
+export type RegisterProjectInput = {
+  name: string;
+  repo_path: string;
+};
+
+export class ProjectValidationError extends Error {
+  readonly field: "name" | "repo_path";
+  readonly code: string;
+  constructor(field: "name" | "repo_path", code: string, message: string) {
+    super(message);
+    this.name = "ProjectValidationError";
+    this.field = field;
+    this.code = code;
+  }
+}
+
+export class ProjectNotFoundError extends Error {
+  readonly id: string;
+  constructor(id: string) {
+    super(`No project with id "${id}"`);
+    this.name = "ProjectNotFoundError";
+    this.id = id;
+  }
+}
+
+const PROJECT_COLUMNS =
+  "id, name, repo_path, default_branch, worktree_root, permissions_mode, created_at";
+
+function rowToProject(row: Record<string, unknown>): Project {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    repo_path: row.repo_path as string,
+    default_branch: row.default_branch as string,
+    worktree_root: row.worktree_root as string,
+    permissions_mode: row.permissions_mode as PermissionsMode,
+    created_at: row.created_at as string,
+  };
+}
+
+function defaultWorktreeRoot(repoPath: string): string {
+  const parent = dirname(repoPath);
+  const name = basename(repoPath);
+  return resolve(parent, ".worktrees", name);
+}
+
+export async function registerProject(db: Database, input: RegisterProjectInput): Promise<Project> {
+  const name = input.name.trim();
+  if (name.length === 0) {
+    throw new ProjectValidationError("name", "required", "Name is required");
+  }
+  if (name.length > 100) {
+    throw new ProjectValidationError("name", "too_long", "Name must be 100 characters or fewer");
+  }
+
+  const rawPath = (input.repo_path ?? "").trim();
+  if (rawPath.length === 0) {
+    throw new ProjectValidationError("repo_path", "required", "Repo path is required");
+  }
+
+  let absolutePath: string;
+  try {
+    absolutePath = await assertGitRepo(rawPath);
+  } catch (err) {
+    if (err instanceof NotAGitRepoError) {
+      throw new ProjectValidationError("repo_path", "not_a_git_repo", err.message);
+    }
+    throw err;
+  }
+
+  const existing = db
+    .prepare<{ id: string }, [string]>("SELECT id FROM projects WHERE repo_path = ?")
+    .get(absolutePath);
+  if (existing) {
+    throw new ProjectValidationError(
+      "repo_path",
+      "already_registered",
+      `A project is already registered at "${absolutePath}"`,
+    );
+  }
+
+  const defaultBranch = await detectDefaultBranch(absolutePath);
+  const worktreeRoot = defaultWorktreeRoot(absolutePath);
+
+  const project: Project = {
+    id: randomUUID(),
+    name,
+    repo_path: absolutePath,
+    default_branch: defaultBranch,
+    worktree_root: worktreeRoot,
+    permissions_mode: "bypassPermissions",
+    created_at: new Date().toISOString(),
+  };
+
+  db.run(`INSERT INTO projects (${PROJECT_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?)`, [
+    project.id,
+    project.name,
+    project.repo_path,
+    project.default_branch,
+    project.worktree_root,
+    project.permissions_mode,
+    project.created_at,
+  ]);
+
+  return project;
+}
+
+export function listProjects(db: Database): Project[] {
+  const rows = db
+    .prepare<Record<string, unknown>, []>(
+      `SELECT ${PROJECT_COLUMNS} FROM projects ORDER BY created_at ASC`,
+    )
+    .all();
+  return rows.map(rowToProject);
+}
+
+export function getProject(db: Database, id: string): Project | null {
+  const row = db
+    .prepare<Record<string, unknown>, [string]>(
+      `SELECT ${PROJECT_COLUMNS} FROM projects WHERE id = ?`,
+    )
+    .get(id);
+  return row ? rowToProject(row) : null;
+}
+
+export function deleteProject(db: Database, id: string): boolean {
+  const result = db.run("DELETE FROM projects WHERE id = ?", [id]);
+  return result.changes > 0;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,66 @@
+export type Project = {
+  id: string;
+  name: string;
+  repo_path: string;
+  default_branch: string;
+  worktree_root: string;
+  permissions_mode: "bypassPermissions" | "acceptEdits";
+  created_at: string;
+};
+
+export type RegisterProjectInput = {
+  name: string;
+  repo_path: string;
+};
+
+export type ApiError = {
+  code: string;
+  field?: string;
+  message: string;
+};
+
+export class ApiRequestError extends Error {
+  readonly status: number;
+  readonly body: ApiError;
+  constructor(status: number, body: ApiError) {
+    super(body.message);
+    this.name = "ApiRequestError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function unwrap<T>(res: Response): Promise<T> {
+  if (res.ok) {
+    if (res.status === 204) return undefined as T;
+    return (await res.json()) as T;
+  }
+  let body: ApiError;
+  try {
+    const json = (await res.json()) as { error?: ApiError };
+    body = json.error ?? { code: "unknown", message: `Request failed (${res.status})` };
+  } catch {
+    body = { code: "unknown", message: `Request failed (${res.status})` };
+  }
+  throw new ApiRequestError(res.status, body);
+}
+
+export async function listProjects(): Promise<Project[]> {
+  const res = await fetch("/api/projects");
+  const data = await unwrap<{ projects: Project[] }>(res);
+  return data.projects;
+}
+
+export async function registerProject(input: RegisterProjectInput): Promise<Project> {
+  const res = await fetch("/api/projects", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return unwrap<Project>(res);
+}
+
+export async function deleteProject(id: string): Promise<void> {
+  const res = await fetch(`/api/projects/${encodeURIComponent(id)}`, { method: "DELETE" });
+  await unwrap<void>(res);
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,16 +1,225 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { FolderGit2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { FolderGit2, GitBranch, Plus, Trash2, X } from "lucide-react";
+import { cn } from "../lib/cn";
+import {
+  ApiRequestError,
+  deleteProject,
+  listProjects,
+  registerProject,
+  type Project,
+} from "../lib/api";
 
 export const Route = createFileRoute("/")({ component: ProjectListRoute });
 
+type FieldErrors = { name?: string; repo_path?: string; form?: string };
+
 function ProjectListRoute() {
+  const [projects, setProjects] = useState<Project[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await listProjects();
+      setProjects(data);
+      setLoadError(null);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : "Failed to load projects");
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleRegistered = useCallback((project: Project) => {
+    setProjects((current) => (current ? [...current, project] : [project]));
+    setShowForm(false);
+  }, []);
+
+  const handleDelete = useCallback(async (project: Project) => {
+    const ok = window.confirm(
+      `Remove "${project.name}" from the registry?\n\nThis only removes the entry. Files at ${project.repo_path} are left alone.`,
+    );
+    if (!ok) return;
+    try {
+      await deleteProject(project.id);
+      setProjects((current) => (current ? current.filter((p) => p.id !== project.id) : current));
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : "Delete failed");
+    }
+  }, []);
+
   return (
     <main className="mx-auto flex min-h-dvh max-w-screen-md flex-col px-5 py-6">
-      <header className="mb-8 flex items-center justify-between">
+      <header className="mb-6 flex items-center justify-between gap-3">
         <h1 className="text-2xl font-semibold tracking-tight">Projects</h1>
+        <button
+          type="button"
+          onClick={() => setShowForm((v) => !v)}
+          className={cn(
+            "inline-flex h-10 items-center gap-2 rounded-lg px-3 text-sm font-medium transition",
+            showForm
+              ? "bg-muted text-foreground hover:bg-accent"
+              : "bg-primary text-primary-foreground hover:opacity-90",
+          )}
+        >
+          {showForm ? (
+            <X className="size-4" aria-hidden />
+          ) : (
+            <Plus className="size-4" aria-hidden />
+          )}
+          <span>{showForm ? "Cancel" : "Register"}</span>
+        </button>
       </header>
-      <EmptyState />
+
+      {showForm && <RegisterForm onRegistered={handleRegistered} />}
+
+      {loadError && (
+        <div className="mb-4 rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {loadError}
+        </div>
+      )}
+
+      {projects === null && !loadError ? (
+        <p className="mt-6 text-sm text-muted-foreground">Loading…</p>
+      ) : projects && projects.length === 0 ? (
+        <EmptyState />
+      ) : projects ? (
+        <ul className="mt-2 flex flex-col gap-3">
+          {projects.map((project) => (
+            <ProjectCard key={project.id} project={project} onDelete={handleDelete} />
+          ))}
+        </ul>
+      ) : null}
     </main>
+  );
+}
+
+function RegisterForm({ onRegistered }: { onRegistered: (project: Project) => void }) {
+  const [name, setName] = useState("");
+  const [repoPath, setRepoPath] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrors({});
+    setSubmitting(true);
+    try {
+      const project = await registerProject({ name, repo_path: repoPath });
+      onRegistered(project);
+      setName("");
+      setRepoPath("");
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        const field = err.body.field;
+        if (field === "name" || field === "repo_path") {
+          setErrors({ [field]: err.body.message });
+        } else {
+          setErrors({ form: err.body.message });
+        }
+      } else {
+        setErrors({ form: err instanceof Error ? err.message : "Registration failed" });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="mb-6 flex flex-col gap-4 rounded-2xl border border-border/60 bg-card p-5"
+    >
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="project-name" className="text-sm font-medium">
+          Name
+        </label>
+        <input
+          id="project-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="my-project"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className={inputClass(!!errors.name)}
+        />
+        {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="project-repo-path" className="text-sm font-medium">
+          Repo path
+        </label>
+        <input
+          id="project-repo-path"
+          value={repoPath}
+          onChange={(e) => setRepoPath(e.target.value)}
+          placeholder="/Users/me/code/my-project"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className={cn(inputClass(!!errors.repo_path), "font-mono text-sm")}
+        />
+        {errors.repo_path && <p className="text-xs text-destructive">{errors.repo_path}</p>}
+        <p className="text-xs text-muted-foreground">
+          Absolute path to a git repository on this machine.
+        </p>
+      </div>
+
+      {errors.form && (
+        <p className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {errors.form}
+        </p>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex h-10 items-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? "Registering…" : "Register project"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function ProjectCard({
+  project,
+  onDelete,
+}: {
+  project: Project;
+  onDelete: (project: Project) => void;
+}) {
+  return (
+    <li className="flex items-start justify-between gap-3 rounded-2xl border border-border/60 bg-card p-4">
+      <div className="min-w-0 flex-1">
+        <h2 className="truncate text-base font-semibold">{project.name}</h2>
+        <p
+          className="mt-1 truncate font-mono text-xs text-muted-foreground"
+          title={project.repo_path}
+        >
+          {project.repo_path}
+        </p>
+        <div className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+          <GitBranch className="size-3" aria-hidden />
+          <span className="font-mono">{project.default_branch}</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => onDelete(project)}
+        aria-label={`Delete ${project.name}`}
+        className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+      >
+        <Trash2 className="size-4" aria-hidden />
+      </button>
+    </li>
   );
 }
 
@@ -22,9 +231,16 @@ function EmptyState() {
       </div>
       <h2 className="text-lg font-medium">No projects yet</h2>
       <p className="mt-2 max-w-sm text-sm text-muted-foreground">
-        Register a directory on your machine to drive Claude Code from your phone. Project
-        registration lands in a later slice.
+        Register a directory on your machine to drive Claude Code from your phone.
       </p>
     </div>
+  );
+}
+
+function inputClass(hasError: boolean): string {
+  return cn(
+    "h-10 w-full rounded-lg border bg-background px-3 text-sm outline-none transition",
+    "border-input focus:border-ring focus:ring-2 focus:ring-ring/30",
+    hasError && "border-destructive focus:border-destructive focus:ring-destructive/30",
   );
 }

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+import { assertGitRepo, detectDefaultBranch, NotAGitRepoError } from "../server/git.ts";
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "claude-remote-git-"));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function initRepo(path: string, initialBranch = "main") {
+  mkdirSync(path, { recursive: true });
+  await $`git -C ${path} init -b ${initialBranch}`.quiet();
+  await $`git -C ${path} config user.email test@example.com`.quiet();
+  await $`git -C ${path} config user.name Test`.quiet();
+  writeFileSync(join(path, "README.md"), "test\n");
+  await $`git -C ${path} add .`.quiet();
+  await $`git -C ${path} commit -m initial`.quiet();
+}
+
+describe("assertGitRepo", () => {
+  test("returns the canonical path for a valid repo root", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const result = await assertGitRepo(repo);
+    expect(result).toBe(realpathSync(repo));
+  });
+
+  test("throws when the path is not a directory", async () => {
+    const missing = join(tempDir, "does-not-exist");
+    await expect(assertGitRepo(missing)).rejects.toBeInstanceOf(NotAGitRepoError);
+  });
+
+  test("throws when the directory is not a git repo", async () => {
+    const plain = join(tempDir, "not-a-repo");
+    mkdirSync(plain);
+    await expect(assertGitRepo(plain)).rejects.toBeInstanceOf(NotAGitRepoError);
+  });
+
+  test("throws when the path is inside a repo but not its root", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const sub = join(repo, "sub");
+    mkdirSync(sub);
+    await expect(assertGitRepo(sub)).rejects.toThrow(/not its root/);
+  });
+});
+
+describe("detectDefaultBranch", () => {
+  test("returns the local branch name when there is no origin", async () => {
+    const repo = join(tempDir, "repo-trunk");
+    await initRepo(repo, "trunk");
+    const branch = await detectDefaultBranch(repo);
+    expect(branch).toBe("trunk");
+  });
+
+  test("uses origin/HEAD when present", async () => {
+    const upstream = join(tempDir, "upstream.git");
+    mkdirSync(upstream);
+    await $`git -C ${upstream} init --bare -b main`.quiet();
+
+    const repo = join(tempDir, "clone");
+    await initRepo(repo, "main");
+    await $`git -C ${repo} remote add origin ${upstream}`.quiet();
+    await $`git -C ${repo} push -u origin main`.quiet();
+
+    // Make a local-only branch and switch to it; origin's HEAD should still
+    // be detected as `main`.
+    await $`git -C ${repo} checkout -b feature/local`.quiet();
+    await $`git -C ${repo} remote set-head origin main`.quiet();
+
+    const branch = await detectDefaultBranch(repo);
+    expect(branch).toBe("main");
+  });
+});

--- a/tests/projects-registry.test.ts
+++ b/tests/projects-registry.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { $ } from "bun";
+import { runMigrationsFromDir } from "../server/db/migrator.ts";
+import {
+  deleteProject,
+  getProject,
+  listProjects,
+  ProjectValidationError,
+  registerProject,
+} from "../server/projects/registry.ts";
+
+const MIGRATIONS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "server",
+  "db",
+  "migrations",
+);
+
+let tempDir: string;
+let db: Database;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "claude-remote-registry-"));
+  db = new Database(":memory:");
+  db.exec("PRAGMA foreign_keys = ON;");
+  runMigrationsFromDir(db, MIGRATIONS_DIR);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function initRepo(path: string, initialBranch = "main") {
+  mkdirSync(path, { recursive: true });
+  await $`git -C ${path} init -b ${initialBranch}`.quiet();
+  await $`git -C ${path} config user.email test@example.com`.quiet();
+  await $`git -C ${path} config user.name Test`.quiet();
+  writeFileSync(join(path, "README.md"), "test\n");
+  await $`git -C ${path} add .`.quiet();
+  await $`git -C ${path} commit -m initial`.quiet();
+}
+
+describe("Project Registry", () => {
+  test("registers a project at a valid git repo with the detected default branch", async () => {
+    const repo = join(tempDir, "alpha");
+    await initRepo(repo, "main");
+
+    const project = await registerProject(db, { name: "Alpha", repo_path: repo });
+    const canonicalRepo = realpathSync(repo);
+    const canonicalParent = realpathSync(tempDir);
+
+    expect(project.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(project.name).toBe("Alpha");
+    expect(project.repo_path).toBe(canonicalRepo);
+    expect(project.default_branch).toBe("main");
+    expect(project.permissions_mode).toBe("bypassPermissions");
+    expect(project.worktree_root).toBe(resolve(canonicalParent, ".worktrees", "alpha"));
+    expect(project.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("trims the project name and rejects empty values", async () => {
+    const repo = join(tempDir, "named");
+    await initRepo(repo);
+
+    await expect(registerProject(db, { name: "   ", repo_path: repo })).rejects.toBeInstanceOf(
+      ProjectValidationError,
+    );
+  });
+
+  test("rejects a path that is not a git repo with a clear validation error", async () => {
+    const plain = join(tempDir, "plain");
+    mkdirSync(plain);
+
+    let thrown: unknown;
+    try {
+      await registerProject(db, { name: "Plain", repo_path: plain });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ProjectValidationError);
+    const err = thrown as ProjectValidationError;
+    expect(err.field).toBe("repo_path");
+    expect(err.code).toBe("not_a_git_repo");
+  });
+
+  test("rejects a missing path with a not_a_git_repo error", async () => {
+    const missing = join(tempDir, "ghost");
+    await expect(registerProject(db, { name: "Ghost", repo_path: missing })).rejects.toMatchObject({
+      field: "repo_path",
+      code: "not_a_git_repo",
+    });
+  });
+
+  test("rejects re-registering the same path", async () => {
+    const repo = join(tempDir, "twice");
+    await initRepo(repo);
+
+    await registerProject(db, { name: "Twice", repo_path: repo });
+
+    await expect(
+      registerProject(db, { name: "Twice Again", repo_path: repo }),
+    ).rejects.toMatchObject({ code: "already_registered" });
+  });
+
+  test("listProjects returns projects in insertion order", async () => {
+    const a = join(tempDir, "a");
+    const b = join(tempDir, "b");
+    await initRepo(a);
+    await initRepo(b);
+
+    await registerProject(db, { name: "A", repo_path: a });
+    // Tiny delay so created_at differs across rows on systems with coarse clocks.
+    await new Promise((r) => setTimeout(r, 5));
+    await registerProject(db, { name: "B", repo_path: b });
+
+    const all = listProjects(db);
+    expect(all.map((p) => p.name)).toEqual(["A", "B"]);
+  });
+
+  test("getProject returns the project by id, or null if missing", async () => {
+    const repo = join(tempDir, "single");
+    await initRepo(repo);
+    const created = await registerProject(db, { name: "Single", repo_path: repo });
+
+    expect(getProject(db, created.id)?.id).toBe(created.id);
+    expect(getProject(db, "nonexistent-id")).toBeNull();
+  });
+
+  test("deleteProject removes the row and returns true; false when missing", async () => {
+    const repo = join(tempDir, "doomed");
+    await initRepo(repo);
+    const created = await registerProject(db, { name: "Doomed", repo_path: repo });
+
+    expect(deleteProject(db, created.id)).toBe(true);
+    expect(getProject(db, created.id)).toBeNull();
+    expect(deleteProject(db, created.id)).toBe(false);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,10 +5,20 @@ import viteReact from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 const port = Number(process.env.PORT ?? 2633);
+const apiPort = Number(process.env.API_PORT ?? 2634);
 
 export default defineConfig({
   resolve: { tsconfigPaths: true },
-  server: { port, host: process.env.HOST ?? "127.0.0.1" },
+  server: {
+    port,
+    host: process.env.HOST ?? "127.0.0.1",
+    proxy: {
+      "/api": {
+        target: `http://127.0.0.1:${apiPort}`,
+        changeOrigin: true,
+      },
+    },
+  },
   preview: { port },
   plugins: [devtools(), tailwindcss(), tanstackStart(), viteReact()],
 });


### PR DESCRIPTION
Closes #3.

## Summary

- **Backend:** new `server/git.ts` (validate-is-git-repo + default-branch detection), `server/projects/registry.ts` (CRUD + structured `ProjectValidationError`), `server/api/handler.ts` exposing `/api/projects` with `GET`/`POST`/`GET /:id`/`DELETE /:id`. `DELETE` removes the registry row only — files are not touched.
- **Dev split:** added `server/dev-api.ts` (`Bun.serve` + `bun:sqlite`) and `scripts/dev.ts`, which launches it alongside `vite dev`. Vite proxies `/api/*` to `API_PORT` (default `2634`). Needed because Vite runs under Node and can't import `bun:sqlite`. Production is unchanged: a single `Bun.serve` in `index.ts` handles the API in front of the SSR bundle.
- **Front-end:** `/` now lists registered projects (name, monospace path, default-branch chip), shows an inline register form with field-level validation surfaced from the API, and a delete confirmation that explicitly notes files are left alone.
- **Tests:** `tests/git.test.ts` and `tests/projects-registry.test.ts` exercise repo detection (including macOS symlink canonicalization via `realpath`), default-branch detection with and without `origin/HEAD`, validation errors, dup-rejection, list ordering, get-by-id, and delete idempotency.
- **README:** documented the new dev split, `API_PORT`, the API surface, and updated the Vite-exception note.

## Test plan

- [x] `bun install`
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` — 25 tests pass (3 files)
- [x] `bun run build` — client + SSR build succeed
- [x] `bun run dev`, register a real repo from the form, confirm it appears with the correct default branch, then delete it and confirm it disappears
- [x] Try registering a non-git path — expect inline `repo_path` error
- [x] Re-register the same path — expect `409` surfaced as inline error

🤖 Generated with [Claude Code](https://claude.com/claude-code)