### PR TITLE
Slice 3: Conversation list with auto-default conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,29 +55,29 @@ The dev server prints its URL on stdout; the production server is started with `
 
 All configuration is via environment variables. There is no config file in v1.
 
-| Variable                 | Default                | Description                                                    |
-| ------------------------ | ---------------------- | -------------------------------------------------------------- |
+| Variable                 | Default                | Description                                                       |
+| ------------------------ | ---------------------- | ----------------------------------------------------------------- |
 | `PORT`                   | `2633`                 | Port the HTTP server listens on (web in dev; everything in prod). |
-| `API_PORT`               | `2634`                 | Dev-only API port that Vite proxies `/api/*` to.               |
-| `HOST`                   | `127.0.0.1`            | Bind address. Set to `0.0.0.0` to expose on the LAN/Tailscale. |
-| `CLAUDE_REMOTE_DATA_DIR` | `~/.claude-remote`     | Directory for SQLite cache and any runtime state.              |
-| `CLAUDE_REMOTE_DB_PATH`  | `<DATA_DIR>/db.sqlite` | Override the SQLite file location directly.                    |
+| `API_PORT`               | `2634`                 | Dev-only API port that Vite proxies `/api/*` to.                  |
+| `HOST`                   | `127.0.0.1`            | Bind address. Set to `0.0.0.0` to expose on the LAN/Tailscale.    |
+| `CLAUDE_REMOTE_DATA_DIR` | `~/.claude-remote`     | Directory for SQLite cache and any runtime state.                 |
+| `CLAUDE_REMOTE_DB_PATH`  | `<DATA_DIR>/db.sqlite` | Override the SQLite file location directly.                       |
 
 ## Scripts
 
-| Script               | Description                                                                 |
-| -------------------- | --------------------------------------------------------------------------- |
+| Script               | Description                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
 | `bun run dev`        | Migrate, then run Vite (web) + a Bun API process side-by-side; Vite proxies `/api/*` to the API. |
-| `bun run dev:api`    | Run only the Bun API process (`server/dev-api.ts`) with `--hot`.            |
-| `bun run dev:web`    | Run only `vite dev` for the front-end.                                      |
-| `bun run build`      | Build the client + SSR bundles for production.                              |
-| `bun run start`      | Run the production server (single `Bun.serve` over the built output, including the API). |
-| `bun run db:migrate` | Apply pending SQL migrations.                                               |
-| `bun run test`       | Run Vitest.                                                                 |
-| `bun run test:watch` | Run Vitest in watch mode.                                                   |
-| `bun run lint`       | Lint with oxlint.                                                           |
-| `bun run format`     | Format with oxfmt.                                                          |
-| `bun run typecheck`  | Type-check with tsgo.                                                       |
+| `bun run dev:api`    | Run only the Bun API process (`server/dev-api.ts`) with `--hot`.                                 |
+| `bun run dev:web`    | Run only `vite dev` for the front-end.                                                           |
+| `bun run build`      | Build the client + SSR bundles for production.                                                   |
+| `bun run start`      | Run the production server (single `Bun.serve` over the built output, including the API).         |
+| `bun run db:migrate` | Apply pending SQL migrations.                                                                    |
+| `bun run test`       | Run Vitest.                                                                                      |
+| `bun run test:watch` | Run Vitest in watch mode.                                                                        |
+| `bun run lint`       | Lint with oxlint.                                                                                |
+| `bun run format`     | Format with oxfmt.                                                                               |
+| `bun run typecheck`  | Type-check with tsgo.                                                                            |
 
 ## Database & migrations
 
@@ -92,12 +92,12 @@ The runner has unit tests in `tests/migrator.test.ts`. Run them with `bun run te
 
 ## HTTP API
 
-| Method   | Path                  | Description                                                                                        |
-| -------- | --------------------- | -------------------------------------------------------------------------------------------------- |
-| `GET`    | `/api/projects`       | List all registered projects.                                                                      |
-| `POST`   | `/api/projects`       | Register `{ name, repo_path }`. Validates the path is a git repo and detects the default branch.  |
-| `GET`    | `/api/projects/:id`   | Get a single project.                                                                              |
-| `DELETE` | `/api/projects/:id`   | Remove the registry row. **Does not** touch the filesystem at `repo_path`.                         |
+| Method   | Path                | Description                                                                                      |
+| -------- | ------------------- | ------------------------------------------------------------------------------------------------ |
+| `GET`    | `/api/projects`     | List all registered projects.                                                                    |
+| `POST`   | `/api/projects`     | Register `{ name, repo_path }`. Validates the path is a git repo and detects the default branch. |
+| `GET`    | `/api/projects/:id` | Get a single project.                                                                            |
+| `DELETE` | `/api/projects/:id` | Remove the registry row. **Does not** touch the filesystem at `repo_path`.                       |
 
 Validation errors return `400` (`409` for re-registering the same path) with `{ error: { code, field?, message } }`.
 

--- a/server/api/handler.ts
+++ b/server/api/handler.ts
@@ -7,6 +7,11 @@ import {
   registerProject,
   type Project,
 } from "../projects/registry.ts";
+import {
+  ensureDefaultConversation,
+  listConversations,
+  type Conversation,
+} from "../conversations/registry.ts";
 
 export type ApiContext = {
   db: Database;
@@ -24,6 +29,11 @@ function projectsListUrl(pathname: string): boolean {
 
 function projectByIdMatch(pathname: string): string | null {
   const m = /^\/api\/projects\/([^/]+)\/?$/.exec(pathname);
+  return m ? decodeURIComponent(m[1]!) : null;
+}
+
+function projectConversationsMatch(pathname: string): string | null {
+  const m = /^\/api\/projects\/([^/]+)\/conversations\/?$/.exec(pathname);
   return m ? decodeURIComponent(m[1]!) : null;
 }
 
@@ -85,6 +95,21 @@ function handleDeleteProject(id: string, ctx: ApiContext): Response {
   return new Response(null, { status: 204 });
 }
 
+async function handleListProjectConversations(
+  projectId: string,
+  ctx: ApiContext,
+): Promise<Response> {
+  const project = getProject(ctx.db, projectId);
+  if (!project) {
+    return json(404, {
+      error: { code: "not_found", message: `No project with id "${projectId}"` },
+    });
+  }
+  await ensureDefaultConversation(ctx.db, project);
+  const conversations: Conversation[] = listConversations(ctx.db, project.id);
+  return json(200, { conversations });
+}
+
 export async function handleApi(req: Request, ctx: ApiContext): Promise<Response | null> {
   const url = new URL(req.url);
   if (!url.pathname.startsWith("/api/")) return null;
@@ -92,6 +117,17 @@ export async function handleApi(req: Request, ctx: ApiContext): Promise<Response
   if (projectsListUrl(url.pathname)) {
     if (req.method === "GET") return handleListProjects(ctx);
     if (req.method === "POST") return handleCreateProject(req, ctx);
+    return json(405, {
+      error: {
+        code: "method_not_allowed",
+        message: `Method ${req.method} not allowed on ${url.pathname}`,
+      },
+    });
+  }
+
+  const conversationsProjectId = projectConversationsMatch(url.pathname);
+  if (conversationsProjectId) {
+    if (req.method === "GET") return handleListProjectConversations(conversationsProjectId, ctx);
     return json(405, {
       error: {
         code: "method_not_allowed",

--- a/server/conversations/registry.ts
+++ b/server/conversations/registry.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "node:crypto";
+import type { Database } from "bun:sqlite";
+import { detectCurrentBranch } from "../git.ts";
+import type { Project } from "../projects/registry.ts";
+
+export type ConversationStatus = "active" | "orphaned" | "archived";
+
+export type Conversation = {
+  id: string;
+  project_id: string;
+  worktree_path: string;
+  branch: string;
+  session_id: string | null;
+  title: string;
+  color: string | null;
+  is_default: boolean;
+  status: ConversationStatus;
+  created_at: string;
+  last_active_at: string;
+};
+
+export class ConversationNotFoundError extends Error {
+  readonly id: string;
+  constructor(id: string) {
+    super(`No conversation with id "${id}"`);
+    this.name = "ConversationNotFoundError";
+    this.id = id;
+  }
+}
+
+const CONVERSATION_COLUMNS =
+  "id, project_id, worktree_path, branch, session_id, title, color, is_default, status, created_at, last_active_at";
+
+function rowToConversation(row: Record<string, unknown>): Conversation {
+  return {
+    id: row.id as string,
+    project_id: row.project_id as string,
+    worktree_path: row.worktree_path as string,
+    branch: row.branch as string,
+    session_id: (row.session_id as string | null) ?? null,
+    title: row.title as string,
+    color: (row.color as string | null) ?? null,
+    is_default: (row.is_default as number) === 1,
+    status: row.status as ConversationStatus,
+    created_at: row.created_at as string,
+    last_active_at: row.last_active_at as string,
+  };
+}
+
+function getDefaultConversation(db: Database, projectId: string): Conversation | null {
+  const row = db
+    .prepare<Record<string, unknown>, [string]>(
+      `SELECT ${CONVERSATION_COLUMNS} FROM conversations
+       WHERE project_id = ? AND is_default = 1 LIMIT 1`,
+    )
+    .get(projectId);
+  return row ? rowToConversation(row) : null;
+}
+
+export async function ensureDefaultConversation(
+  db: Database,
+  project: Project,
+): Promise<Conversation> {
+  const existing = getDefaultConversation(db, project.id);
+  if (existing) return existing;
+
+  const branch = (await detectCurrentBranch(project.repo_path)) ?? project.default_branch;
+  const now = new Date().toISOString();
+  const conversation: Conversation = {
+    id: randomUUID(),
+    project_id: project.id,
+    worktree_path: project.repo_path,
+    branch,
+    session_id: null,
+    title: project.name,
+    color: null,
+    is_default: true,
+    status: "active",
+    created_at: now,
+    last_active_at: now,
+  };
+
+  db.run(
+    `INSERT INTO conversations (${CONVERSATION_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      conversation.id,
+      conversation.project_id,
+      conversation.worktree_path,
+      conversation.branch,
+      conversation.session_id,
+      conversation.title,
+      conversation.color,
+      conversation.is_default ? 1 : 0,
+      conversation.status,
+      conversation.created_at,
+      conversation.last_active_at,
+    ],
+  );
+
+  return conversation;
+}
+
+export function listConversations(db: Database, projectId: string): Conversation[] {
+  const rows = db
+    .prepare<Record<string, unknown>, [string]>(
+      `SELECT ${CONVERSATION_COLUMNS} FROM conversations
+       WHERE project_id = ?
+       ORDER BY is_default DESC, last_active_at DESC`,
+    )
+    .all(projectId);
+  return rows.map(rowToConversation);
+}
+
+export function getConversation(db: Database, id: string): Conversation | null {
+  const row = db
+    .prepare<Record<string, unknown>, [string]>(
+      `SELECT ${CONVERSATION_COLUMNS} FROM conversations WHERE id = ?`,
+    )
+    .get(id);
+  return row ? rowToConversation(row) : null;
+}

--- a/server/git.ts
+++ b/server/git.ts
@@ -65,3 +65,11 @@ export async function detectDefaultBranch(repoPath: string): Promise<string> {
 
   return "main";
 }
+
+export async function detectCurrentBranch(repoPath: string): Promise<string | null> {
+  const absolute = resolve(repoPath);
+  const result = await $`git -C ${absolute} branch --show-current`.quiet().nothrow();
+  if (result.exitCode !== 0) return null;
+  const branch = result.stdout.toString().trim();
+  return branch.length > 0 ? branch : null;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -13,6 +13,22 @@ export type RegisterProjectInput = {
   repo_path: string;
 };
 
+export type ConversationStatus = "active" | "orphaned" | "archived";
+
+export type Conversation = {
+  id: string;
+  project_id: string;
+  worktree_path: string;
+  branch: string;
+  session_id: string | null;
+  title: string;
+  color: string | null;
+  is_default: boolean;
+  status: ConversationStatus;
+  created_at: string;
+  last_active_at: string;
+};
+
 export type ApiError = {
   code: string;
   field?: string;
@@ -63,4 +79,15 @@ export async function registerProject(input: RegisterProjectInput): Promise<Proj
 export async function deleteProject(id: string): Promise<void> {
   const res = await fetch(`/api/projects/${encodeURIComponent(id)}`, { method: "DELETE" });
   await unwrap<void>(res);
+}
+
+export async function getProject(id: string): Promise<Project> {
+  const res = await fetch(`/api/projects/${encodeURIComponent(id)}`);
+  return unwrap<Project>(res);
+}
+
+export async function listConversations(projectId: string): Promise<Conversation[]> {
+  const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/conversations`);
+  const data = await unwrap<{ conversations: Conversation[] }>(res);
+  return data.conversations;
 }

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,23 @@
+const UNITS: { label: string; seconds: number }[] = [
+  { label: "y", seconds: 60 * 60 * 24 * 365 },
+  { label: "mo", seconds: 60 * 60 * 24 * 30 },
+  { label: "w", seconds: 60 * 60 * 24 * 7 },
+  { label: "d", seconds: 60 * 60 * 24 },
+  { label: "h", seconds: 60 * 60 },
+  { label: "m", seconds: 60 },
+];
+
+export function formatRelativeTime(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const diffSeconds = Math.round((now.getTime() - then) / 1000);
+  const abs = Math.abs(diffSeconds);
+  if (abs < 45) return "just now";
+  for (const unit of UNITS) {
+    if (abs >= unit.seconds) {
+      const value = Math.round(abs / unit.seconds);
+      return diffSeconds >= 0 ? `${value}${unit.label} ago` : `in ${value}${unit.label}`;
+    }
+  }
+  return "just now";
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
 import { FolderGit2, GitBranch, Plus, Trash2, X } from "lucide-react";
 import { cn } from "../lib/cn";
@@ -197,8 +197,12 @@ function ProjectCard({
   onDelete: (project: Project) => void;
 }) {
   return (
-    <li className="flex items-start justify-between gap-3 rounded-2xl border border-border/60 bg-card p-4">
-      <div className="min-w-0 flex-1">
+    <li className="relative rounded-2xl border border-border/60 bg-card transition hover:border-border">
+      <Link
+        to="/projects/$projectId"
+        params={{ projectId: project.id }}
+        className="block p-4 pr-14"
+      >
         <h2 className="truncate text-base font-semibold">{project.name}</h2>
         <p
           className="mt-1 truncate font-mono text-xs text-muted-foreground"
@@ -210,12 +214,16 @@ function ProjectCard({
           <GitBranch className="size-3" aria-hidden />
           <span className="font-mono">{project.default_branch}</span>
         </div>
-      </div>
+      </Link>
       <button
         type="button"
-        onClick={() => onDelete(project)}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onDelete(project);
+        }}
         aria-label={`Delete ${project.name}`}
-        className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+        className="absolute right-3 top-3 inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
       >
         <Trash2 className="size-4" aria-hidden />
       </button>

--- a/src/routes/projects.$projectId.tsx
+++ b/src/routes/projects.$projectId.tsx
@@ -1,0 +1,162 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useCallback, useEffect, useState } from "react";
+import { ChevronLeft, GitBranch, MessagesSquare, Pin } from "lucide-react";
+import { cn } from "../lib/cn";
+import { formatRelativeTime } from "../lib/time";
+import {
+  ApiRequestError,
+  getProject,
+  listConversations,
+  type Conversation,
+  type Project,
+} from "../lib/api";
+
+export const Route = createFileRoute("/projects/$projectId")({
+  component: ProjectDetailRoute,
+});
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "ok"; project: Project; conversations: Conversation[] }
+  | { kind: "not_found" }
+  | { kind: "error"; message: string };
+
+function ProjectDetailRoute() {
+  const { projectId } = Route.useParams();
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  const refresh = useCallback(async () => {
+    try {
+      const [project, conversations] = await Promise.all([
+        getProject(projectId),
+        listConversations(projectId),
+      ]);
+      setState({ kind: "ok", project, conversations });
+    } catch (err) {
+      if (err instanceof ApiRequestError && err.status === 404) {
+        setState({ kind: "not_found" });
+        return;
+      }
+      setState({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Failed to load project",
+      });
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-screen-md flex-col px-5 py-6">
+      <Link
+        to="/"
+        className="mb-4 inline-flex items-center gap-1 self-start text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" aria-hidden />
+        <span>Projects</span>
+      </Link>
+
+      {state.kind === "loading" && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+      {state.kind === "not_found" && (
+        <div className="rounded-2xl border border-border/60 bg-card p-6 text-sm">
+          <h1 className="text-lg font-semibold">Project not found</h1>
+          <p className="mt-2 text-muted-foreground">
+            The project may have been removed from the registry.
+          </p>
+        </div>
+      )}
+
+      {state.kind === "error" && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {state.message}
+        </div>
+      )}
+
+      {state.kind === "ok" && (
+        <ProjectDetail project={state.project} conversations={state.conversations} />
+      )}
+    </main>
+  );
+}
+
+function ProjectDetail({
+  project,
+  conversations,
+}: {
+  project: Project;
+  conversations: Conversation[];
+}) {
+  return (
+    <>
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight">{project.name}</h1>
+        <p
+          className="mt-1 truncate font-mono text-xs text-muted-foreground"
+          title={project.repo_path}
+        >
+          {project.repo_path}
+        </p>
+        <div className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+          <GitBranch className="size-3" aria-hidden />
+          <span className="font-mono">{project.default_branch}</span>
+        </div>
+      </header>
+
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-muted-foreground">Conversations</h2>
+        {conversations.length === 0 ? (
+          <ConversationsEmpty />
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {conversations.map((conversation) => (
+              <ConversationCard key={conversation.id} conversation={conversation} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </>
+  );
+}
+
+function ConversationCard({ conversation }: { conversation: Conversation }) {
+  return (
+    <li
+      className={cn(
+        "flex items-start justify-between gap-3 rounded-2xl border bg-card p-4",
+        conversation.is_default ? "border-primary/40" : "border-border/60",
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          {conversation.is_default && (
+            <Pin className="size-3.5 shrink-0 text-primary" aria-label="Default conversation" />
+          )}
+          <h3 className="truncate text-base font-semibold">{conversation.title}</h3>
+        </div>
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5">
+            <GitBranch className="size-3" aria-hidden />
+            <span className="font-mono">{conversation.branch}</span>
+          </span>
+          <time dateTime={conversation.last_active_at}>
+            {formatRelativeTime(conversation.last_active_at)}
+          </time>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function ConversationsEmpty() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border/60 px-6 py-12 text-center">
+      <div className="mb-3 flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <MessagesSquare className="size-5" aria-hidden />
+      </div>
+      <p className="text-sm text-muted-foreground">No conversations yet.</p>
+    </div>
+  );
+}

--- a/tests/conversations-registry.test.ts
+++ b/tests/conversations-registry.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { $ } from "bun";
+import { runMigrationsFromDir } from "../server/db/migrator.ts";
+import { registerProject } from "../server/projects/registry.ts";
+import {
+  ensureDefaultConversation,
+  getConversation,
+  listConversations,
+} from "../server/conversations/registry.ts";
+
+const MIGRATIONS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "server",
+  "db",
+  "migrations",
+);
+
+let tempDir: string;
+let db: Database;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "claude-remote-conversations-"));
+  db = new Database(":memory:");
+  db.exec("PRAGMA foreign_keys = ON;");
+  runMigrationsFromDir(db, MIGRATIONS_DIR);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function initRepo(path: string, initialBranch = "main") {
+  mkdirSync(path, { recursive: true });
+  await $`git -C ${path} init -b ${initialBranch}`.quiet();
+  await $`git -C ${path} config user.email test@example.com`.quiet();
+  await $`git -C ${path} config user.name Test`.quiet();
+  writeFileSync(join(path, "README.md"), "test\n");
+  await $`git -C ${path} add .`.quiet();
+  await $`git -C ${path} commit -m initial`.quiet();
+}
+
+async function makeProject(name: string, branch = "main") {
+  const repo = join(tempDir, name);
+  await initRepo(repo, branch);
+  return registerProject(db, { name, repo_path: repo });
+}
+
+describe("Conversations Registry", () => {
+  test("ensureDefaultConversation creates the default conversation on first call", async () => {
+    const project = await makeProject("Alpha");
+
+    const conversation = await ensureDefaultConversation(db, project);
+
+    expect(conversation.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(conversation.project_id).toBe(project.id);
+    expect(conversation.worktree_path).toBe(project.repo_path);
+    expect(conversation.branch).toBe("main");
+    expect(conversation.title).toBe("Alpha");
+    expect(conversation.is_default).toBe(true);
+    expect(conversation.status).toBe("active");
+    expect(conversation.session_id).toBeNull();
+    expect(conversation.color).toBeNull();
+    expect(conversation.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(conversation.last_active_at).toBe(conversation.created_at);
+  });
+
+  test("ensureDefaultConversation is idempotent", async () => {
+    const project = await makeProject("Beta");
+
+    const first = await ensureDefaultConversation(db, project);
+    const second = await ensureDefaultConversation(db, project);
+
+    expect(second.id).toBe(first.id);
+    expect(listConversations(db, project.id)).toHaveLength(1);
+  });
+
+  test("ensureDefaultConversation captures the repo's current branch, not the default branch", async () => {
+    const project = await makeProject("Gamma", "main");
+    await $`git -C ${project.repo_path} checkout -b feature/x`.quiet();
+
+    const conversation = await ensureDefaultConversation(db, project);
+    expect(conversation.branch).toBe("feature/x");
+  });
+
+  test("listConversations returns the default first, then others by last_active_at desc", async () => {
+    const project = await makeProject("Delta");
+    await ensureDefaultConversation(db, project);
+
+    const baseTime = Date.parse("2026-01-01T00:00:00.000Z");
+    const insertExtra = (suffix: string, lastActiveAt: string) => {
+      db.run(
+        `INSERT INTO conversations
+         (id, project_id, worktree_path, branch, session_id, title, color, is_default, status, created_at, last_active_at)
+         VALUES (?, ?, ?, ?, NULL, ?, NULL, 0, 'active', ?, ?)`,
+        [
+          `extra-${suffix}`,
+          project.id,
+          `${project.worktree_root}/${suffix}`,
+          `feat/${suffix}`,
+          `Extra ${suffix}`,
+          new Date(baseTime).toISOString(),
+          lastActiveAt,
+        ],
+      );
+    };
+
+    insertExtra("old", new Date(baseTime + 1_000).toISOString());
+    insertExtra("new", new Date(baseTime + 5_000).toISOString());
+    insertExtra("mid", new Date(baseTime + 3_000).toISOString());
+
+    const list = listConversations(db, project.id);
+    expect(list).toHaveLength(4);
+    expect(list[0]!.is_default).toBe(true);
+    expect(list.slice(1).map((c) => c.id)).toEqual(["extra-new", "extra-mid", "extra-old"]);
+  });
+
+  test("listConversations returns an empty array for a project with no rows", async () => {
+    const project = await makeProject("Empty");
+    expect(listConversations(db, project.id)).toEqual([]);
+  });
+
+  test("getConversation returns the conversation by id, or null if missing", async () => {
+    const project = await makeProject("Lookup");
+    const created = await ensureDefaultConversation(db, project);
+
+    expect(getConversation(db, created.id)?.id).toBe(created.id);
+    expect(getConversation(db, "nope")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #4. Part of #1.

## Summary

- New `server/conversations/registry.ts` with `ensureDefaultConversation`, `listConversations`, and `getConversation`. Default conversations are created lazily on first list call, capturing the repo's *current* branch (not the project's default branch) so the list reflects what `git` actually says today.
- New `GET /api/projects/:id/conversations` endpoint that runs `ensureDefaultConversation` then returns the list.
- New project detail route at `/projects/$projectId` showing the project header and a conversation list — default pinned at top, worktree-backed below sorted by `last_active_at desc`. Each row shows branch + recency timestamp.
- Project list cards now link to the detail page (delete button stops propagation).
- Tiny `formatRelativeTime` helper for the recency timestamp.

The `conversations` table itself was already created in Slice 2's `001_init.sql` migration, so no new migration is needed.

## Test plan

- [x] `bun run test` (31 passing — added 6 conversation store tests)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] Manual smoke: register a project, hit `GET /api/projects/:id/conversations` cold → returns one row with `is_default: true` and the current git branch; hit it again → still one row.
- [x] Verified 404 on unknown project id and 405 on POST to the conversations route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)