### PR TITLE
Slice 4: First chat — Session Manager, Transcript Reader, WS streaming

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "claude-remote",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "@base-ui-components/react": "^1.0.0-rc.0",
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-devtools": "latest",
@@ -38,6 +39,26 @@
     },
   },
   "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.119", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119", "", { "os": "darwin", "cpu": "x64" }, "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119", "", { "os": "linux", "cpu": "arm64" }, "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119", "", { "os": "linux", "cpu": "arm64" }, "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119", "", { "os": "linux", "cpu": "x64" }, "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119", "", { "os": "linux", "cpu": "x64" }, "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119", "", { "os": "win32", "cpu": "arm64" }, "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119", "", { "os": "win32", "cpu": "x64" }, "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -148,6 +169,8 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -157,6 +180,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -430,6 +455,12 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
@@ -450,6 +481,8 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -457,6 +490,12 @@
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001790", "", {}, "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw=="],
 
@@ -472,9 +511,21 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
@@ -485,6 +536,8 @@
     "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -502,7 +555,13 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
@@ -510,25 +569,59 @@
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.4.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw=="],
+
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
@@ -536,15 +629,31 @@
 
     "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "h3-v2": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
 
     "happy-dom": ["happy-dom@15.11.7", "", { "dependencies": { "entities": "^4.5.0", "webidl-conversions": "^7.0.0", "whatwg-mimetype": "^3.0.0" } }, "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg=="],
 
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
+
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -554,15 +663,27 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "isbot": ["isbot@5.1.39", "", {}, "sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -600,9 +721,21 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
@@ -610,7 +743,15 @@
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "oxfmt": ["oxfmt@0.46.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.46.0", "@oxfmt/binding-android-arm64": "0.46.0", "@oxfmt/binding-darwin-arm64": "0.46.0", "@oxfmt/binding-darwin-x64": "0.46.0", "@oxfmt/binding-freebsd-x64": "0.46.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.46.0", "@oxfmt/binding-linux-arm-musleabihf": "0.46.0", "@oxfmt/binding-linux-arm64-gnu": "0.46.0", "@oxfmt/binding-linux-arm64-musl": "0.46.0", "@oxfmt/binding-linux-ppc64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-gnu": "0.46.0", "@oxfmt/binding-linux-riscv64-musl": "0.46.0", "@oxfmt/binding-linux-s390x-gnu": "0.46.0", "@oxfmt/binding-linux-x64-gnu": "0.46.0", "@oxfmt/binding-linux-x64-musl": "0.46.0", "@oxfmt/binding-openharmony-arm64": "0.46.0", "@oxfmt/binding-win32-arm64-msvc": "0.46.0", "@oxfmt/binding-win32-ia32-msvc": "0.46.0", "@oxfmt/binding-win32-x64-msvc": "0.46.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA=="],
 
@@ -622,17 +763,33 @@
 
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
@@ -642,6 +799,8 @@
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
@@ -650,17 +809,37 @@
 
     "rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
     "seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
 
     "seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
 
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
@@ -673,6 +852,8 @@
     "srvx": ["srvx@0.11.15", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
@@ -696,9 +877,15 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
@@ -706,11 +893,15 @@
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
@@ -726,7 +917,11 @@
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
@@ -735,6 +930,8 @@
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -762,6 +959,8 @@
 
     "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
+    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
@@ -769,5 +968,7 @@
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,15 @@ import { loadConfig } from "./server/config.ts";
 import { openDatabase } from "./server/db/client.ts";
 import { runMigrationsFromDir } from "./server/db/migrator.ts";
 import { handleApi } from "./server/api/handler.ts";
+import { SessionManager } from "./server/sessions/manager.ts";
+import { sdkSpawner } from "./server/sessions/sdk-spawner.ts";
+import {
+  attachWebSocket,
+  detachWebSocket,
+  handleClientMessage,
+  parseClientMessage,
+  type WsAttachment,
+} from "./server/ws/transport.ts";
 
 const ROOT = import.meta.dir;
 const MIGRATIONS_DIR = resolve(ROOT, "server/db/migrations");
@@ -16,6 +25,12 @@ const db = openDatabase(config.dbPath);
 const result = runMigrationsFromDir(db, MIGRATIONS_DIR);
 if (result.applied.length > 0) {
   console.log(`[db] applied ${result.applied.length} migration(s) on startup`);
+}
+
+const sessions = new SessionManager({ db, spawner: sdkSpawner });
+const pruned = sessions.pruneStaleEntries();
+if (pruned > 0) {
+  console.log(`[db] pruned ${pruned} stale session_ledger entr${pruned === 1 ? "y" : "ies"}`);
 }
 
 const ssr = (await import(SERVER_ENTRY)) as {
@@ -32,18 +47,44 @@ async function serveStatic(pathname: string): Promise<Response | null> {
   return new Response(Bun.file(target));
 }
 
-const server = Bun.serve({
+const WS_PATTERN = /^\/api\/conversations\/([^/]+)\/ws\/?$/;
+
+const server = Bun.serve<WsAttachment>({
   port: config.port,
   hostname: config.host,
   idleTimeout: 30,
-  async fetch(req) {
-    const apiResponse = await handleApi(req, { db });
+  async fetch(req, srv) {
+    const url = new URL(req.url);
+    const wsMatch = WS_PATTERN.exec(url.pathname);
+    if (wsMatch) {
+      const conversationId = decodeURIComponent(wsMatch[1]!);
+      const data: WsAttachment = { conversationId };
+      const upgraded = srv.upgrade(req, { data });
+      if (upgraded) return undefined as unknown as Response;
+      return new Response("WebSocket upgrade failed", { status: 426 });
+    }
+
+    const apiResponse = await handleApi(req, { db, sessions });
     if (apiResponse) return apiResponse;
 
-    const url = new URL(req.url);
     const asset = await serveStatic(url.pathname);
     if (asset) return asset;
     return ssr.default.fetch(req);
+  },
+  websocket: {
+    open(ws) {
+      const populated = attachWebSocket(ws, ws.data.conversationId, sessions);
+      ws.data.unsubscribe = populated.unsubscribe;
+      ws.data.heartbeat = populated.heartbeat;
+    },
+    message: async (ws, raw) => {
+      const message = parseClientMessage(raw);
+      if (!message) return;
+      await handleClientMessage(message, ws.data.conversationId, sessions, ws);
+    },
+    close(ws) {
+      detachWebSocket(ws.data);
+    },
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.119",
     "@base-ui-components/react": "^1.0.0-rc.0",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-devtools": "latest",

--- a/server/api/handler.ts
+++ b/server/api/handler.ts
@@ -9,12 +9,17 @@ import {
 } from "../projects/registry.ts";
 import {
   ensureDefaultConversation,
+  getConversation,
   listConversations,
   type Conversation,
 } from "../conversations/registry.ts";
+import type { SessionManager } from "../sessions/manager.ts";
+import { SessionStartError } from "../sessions/manager.ts";
+import { readTranscript } from "../transcript/reader.ts";
 
 export type ApiContext = {
   db: Database;
+  sessions: SessionManager;
 };
 
 const json = (status: number, body: unknown): Response =>
@@ -34,6 +39,16 @@ function projectByIdMatch(pathname: string): string | null {
 
 function projectConversationsMatch(pathname: string): string | null {
   const m = /^\/api\/projects\/([^/]+)\/conversations\/?$/.exec(pathname);
+  return m ? decodeURIComponent(m[1]!) : null;
+}
+
+function conversationByIdMatch(pathname: string): string | null {
+  const m = /^\/api\/conversations\/([^/]+)\/?$/.exec(pathname);
+  return m ? decodeURIComponent(m[1]!) : null;
+}
+
+function conversationMessagesMatch(pathname: string): string | null {
+  const m = /^\/api\/conversations\/([^/]+)\/messages\/?$/.exec(pathname);
   return m ? decodeURIComponent(m[1]!) : null;
 }
 
@@ -110,6 +125,62 @@ async function handleListProjectConversations(
   return json(200, { conversations });
 }
 
+function handleGetConversation(id: string, ctx: ApiContext): Response {
+  const conversation = getConversation(ctx.db, id);
+  if (!conversation) {
+    return json(404, {
+      error: { code: "not_found", message: `No conversation with id "${id}"` },
+    });
+  }
+  return json(200, conversation);
+}
+
+async function handleGetConversationMessages(id: string, ctx: ApiContext): Promise<Response> {
+  const conversation = getConversation(ctx.db, id);
+  if (!conversation) {
+    return json(404, {
+      error: { code: "not_found", message: `No conversation with id "${id}"` },
+    });
+  }
+  if (!conversation.session_id) {
+    return json(200, { messages: [] });
+  }
+  const messages = await readTranscript({
+    cwd: conversation.worktree_path,
+    sessionId: conversation.session_id,
+  });
+  return json(200, { messages });
+}
+
+async function handleSendConversationMessage(
+  id: string,
+  req: Request,
+  ctx: ApiContext,
+): Promise<Response> {
+  const body = await readJson(req);
+  if (!isPlainObject(body) || typeof body.text !== "string") {
+    return json(400, {
+      error: { code: "invalid_body", message: "Body must be { text: string }" },
+    });
+  }
+  const conversation = getConversation(ctx.db, id);
+  if (!conversation) {
+    return json(404, {
+      error: { code: "not_found", message: `No conversation with id "${id}"` },
+    });
+  }
+  try {
+    await ctx.sessions.send(id, body.text);
+    return json(202, { ok: true });
+  } catch (err) {
+    if (err instanceof SessionStartError) {
+      const status = err.code === "worktree_in_use" ? 409 : 400;
+      return json(status, { error: { code: err.code, message: err.message } });
+    }
+    throw err;
+  }
+}
+
 export async function handleApi(req: Request, ctx: ApiContext): Promise<Response | null> {
   const url = new URL(req.url);
   if (!url.pathname.startsWith("/api/")) return null;
@@ -128,6 +199,30 @@ export async function handleApi(req: Request, ctx: ApiContext): Promise<Response
   const conversationsProjectId = projectConversationsMatch(url.pathname);
   if (conversationsProjectId) {
     if (req.method === "GET") return handleListProjectConversations(conversationsProjectId, ctx);
+    return json(405, {
+      error: {
+        code: "method_not_allowed",
+        message: `Method ${req.method} not allowed on ${url.pathname}`,
+      },
+    });
+  }
+
+  const conversationMessagesId = conversationMessagesMatch(url.pathname);
+  if (conversationMessagesId) {
+    if (req.method === "GET") return handleGetConversationMessages(conversationMessagesId, ctx);
+    if (req.method === "POST")
+      return handleSendConversationMessage(conversationMessagesId, req, ctx);
+    return json(405, {
+      error: {
+        code: "method_not_allowed",
+        message: `Method ${req.method} not allowed on ${url.pathname}`,
+      },
+    });
+  }
+
+  const conversationId = conversationByIdMatch(url.pathname);
+  if (conversationId) {
+    if (req.method === "GET") return handleGetConversation(conversationId, ctx);
     return json(405, {
       error: {
         code: "method_not_allowed",

--- a/server/dev-api.ts
+++ b/server/dev-api.ts
@@ -3,6 +3,15 @@ import { loadConfig } from "./config.ts";
 import { openDatabase } from "./db/client.ts";
 import { runMigrationsFromDir } from "./db/migrator.ts";
 import { handleApi } from "./api/handler.ts";
+import { SessionManager } from "./sessions/manager.ts";
+import { sdkSpawner } from "./sessions/sdk-spawner.ts";
+import {
+  attachWebSocket,
+  detachWebSocket,
+  handleClientMessage,
+  parseClientMessage,
+  type WsAttachment,
+} from "./ws/transport.ts";
 
 const ROOT = resolve(import.meta.dir, "..");
 const MIGRATIONS_DIR = resolve(ROOT, "server/db/migrations");
@@ -14,20 +23,52 @@ if (result.applied.length > 0) {
   console.log(`[dev-api] applied ${result.applied.length} migration(s) on startup`);
 }
 
+const sessions = new SessionManager({ db, spawner: sdkSpawner });
+const pruned = sessions.pruneStaleEntries();
+if (pruned > 0) {
+  console.log(`[dev-api] pruned ${pruned} stale session_ledger entr${pruned === 1 ? "y" : "ies"}`);
+}
+
 const apiPortValue = process.env.API_PORT ?? "2634";
 const apiPort = Number.parseInt(apiPortValue, 10);
 if (!Number.isInteger(apiPort) || apiPort <= 0 || apiPort > 65535) {
   throw new Error(`Invalid API_PORT="${apiPortValue}"`);
 }
 
-const server = Bun.serve({
+const WS_PATTERN = /^\/api\/conversations\/([^/]+)\/ws\/?$/;
+
+const server = Bun.serve<WsAttachment>({
   port: apiPort,
   hostname: config.host,
   idleTimeout: 30,
-  async fetch(req) {
-    const response = await handleApi(req, { db });
+  async fetch(req, srv) {
+    const url = new URL(req.url);
+    const wsMatch = WS_PATTERN.exec(url.pathname);
+    if (wsMatch) {
+      const conversationId = decodeURIComponent(wsMatch[1]!);
+      const data: WsAttachment = { conversationId };
+      const upgraded = srv.upgrade(req, { data });
+      if (upgraded) return undefined as unknown as Response;
+      return new Response("WebSocket upgrade failed", { status: 426 });
+    }
+    const response = await handleApi(req, { db, sessions });
     if (response) return response;
     return new Response("Not Found", { status: 404 });
+  },
+  websocket: {
+    open(ws) {
+      const populated = attachWebSocket(ws, ws.data.conversationId, sessions);
+      ws.data.unsubscribe = populated.unsubscribe;
+      ws.data.heartbeat = populated.heartbeat;
+    },
+    message: async (ws, raw) => {
+      const message = parseClientMessage(raw);
+      if (!message) return;
+      await handleClientMessage(message, ws.data.conversationId, sessions, ws);
+    },
+    close(ws) {
+      detachWebSocket(ws.data);
+    },
   },
 });
 

--- a/server/sessions/input-stream.ts
+++ b/server/sessions/input-stream.ts
@@ -1,0 +1,42 @@
+import type { SpawnInputMessage } from "./types.ts";
+
+export class InputStream implements AsyncIterable<SpawnInputMessage> {
+  private queue: SpawnInputMessage[] = [];
+  private resolvers: Array<(result: IteratorResult<SpawnInputMessage>) => void> = [];
+  private closed = false;
+
+  push(message: SpawnInputMessage): void {
+    if (this.closed) return;
+    const next = this.resolvers.shift();
+    if (next) {
+      next({ value: message, done: false });
+      return;
+    }
+    this.queue.push(message);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const resolve of this.resolvers) {
+      resolve({ value: undefined as unknown as SpawnInputMessage, done: true });
+    }
+    this.resolvers.length = 0;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<SpawnInputMessage> {
+    return {
+      next: (): Promise<IteratorResult<SpawnInputMessage>> => {
+        const buffered = this.queue.shift();
+        if (buffered) return Promise.resolve({ value: buffered, done: false });
+        if (this.closed) {
+          return Promise.resolve({
+            value: undefined as unknown as SpawnInputMessage,
+            done: true,
+          });
+        }
+        return new Promise((resolve) => this.resolvers.push(resolve));
+      },
+    };
+  }
+}

--- a/server/sessions/manager.ts
+++ b/server/sessions/manager.ts
@@ -1,0 +1,377 @@
+import type { Database } from "bun:sqlite";
+import type { AssistantBlock } from "../transcript/reader.ts";
+import { InputStream } from "./input-stream.ts";
+import type { Listener, SessionEvent, SpawnedSDKMessage, Spawner } from "./types.ts";
+
+export class SessionStartError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "SessionStartError";
+    this.code = code;
+  }
+}
+
+export type SessionManagerOptions = {
+  db: Database;
+  spawner: Spawner;
+  isPidAlive?: (pid: number) => boolean;
+  hostPid?: number;
+};
+
+export type SessionInfo = {
+  conversation_id: string;
+  sdk_session_id: string;
+  host_pid: number;
+};
+
+type ActiveSession = {
+  conversation_id: string;
+  worktree_path: string;
+  sdk_session_id: string;
+  host_pid: number;
+  input: InputStream;
+  abort: () => void;
+};
+
+type ConversationRow = {
+  id: string;
+  worktree_path: string;
+};
+
+const defaultIsPidAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export class SessionManager {
+  private readonly db: Database;
+  private readonly spawner: Spawner;
+  private readonly isPidAlive: (pid: number) => boolean;
+  private readonly hostPid: number;
+
+  private readonly active = new Map<string, ActiveSession>();
+  private readonly inflight = new Map<string, Promise<SessionInfo>>();
+  private readonly subscribers = new Map<string, Set<Listener>>();
+  private readonly buffered = new Map<string, SessionEvent[]>();
+
+  constructor(options: SessionManagerOptions) {
+    this.db = options.db;
+    this.spawner = options.spawner;
+    this.isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
+    this.hostPid = options.hostPid ?? process.pid;
+  }
+
+  pruneStaleEntries(): number {
+    const rows = this.db
+      .prepare<{ conversation_id: string; host_pid: number }, []>(
+        "SELECT conversation_id, host_pid FROM session_ledger",
+      )
+      .all();
+    let pruned = 0;
+    for (const row of rows) {
+      if (!this.isPidAlive(row.host_pid)) {
+        this.db.run("DELETE FROM session_ledger WHERE conversation_id = ?", [row.conversation_id]);
+        pruned += 1;
+      }
+    }
+    return pruned;
+  }
+
+  hasActiveSession(conversationId: string): boolean {
+    return this.active.has(conversationId);
+  }
+
+  subscribe(conversationId: string, listener: Listener): () => void {
+    let group = this.subscribers.get(conversationId);
+    if (!group) {
+      group = new Set();
+      this.subscribers.set(conversationId, group);
+    }
+    group.add(listener);
+    return () => {
+      const g = this.subscribers.get(conversationId);
+      if (!g) return;
+      g.delete(listener);
+      if (g.size === 0) this.subscribers.delete(conversationId);
+    };
+  }
+
+  bufferedEvents(conversationId: string): SessionEvent[] {
+    return [...(this.buffered.get(conversationId) ?? [])];
+  }
+
+  async start(conversationId: string): Promise<SessionInfo> {
+    const inflight = this.inflight.get(conversationId);
+    if (inflight) return inflight;
+
+    const existing = this.active.get(conversationId);
+    if (existing && this.isPidAlive(existing.host_pid)) {
+      return {
+        conversation_id: existing.conversation_id,
+        sdk_session_id: existing.sdk_session_id,
+        host_pid: existing.host_pid,
+      };
+    }
+
+    const ledgerRow = this.db
+      .prepare<{ conversation_id: string; sdk_session_id: string; host_pid: number }, [string]>(
+        "SELECT conversation_id, sdk_session_id, host_pid FROM session_ledger WHERE conversation_id = ?",
+      )
+      .get(conversationId);
+    if (ledgerRow && !this.isPidAlive(ledgerRow.host_pid)) {
+      this.db.run("DELETE FROM session_ledger WHERE conversation_id = ?", [conversationId]);
+    } else if (ledgerRow && !existing) {
+      this.db.run("DELETE FROM session_ledger WHERE conversation_id = ?", [conversationId]);
+    }
+
+    const promise = this.doSpawn(conversationId);
+    this.inflight.set(conversationId, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inflight.delete(conversationId);
+    }
+  }
+
+  async send(conversationId: string, text: string): Promise<void> {
+    const session = this.active.get(conversationId) ?? null;
+    if (!session) {
+      await this.start(conversationId);
+    }
+    const active = this.active.get(conversationId);
+    if (!active) {
+      throw new SessionStartError("not_started", "Session is not running");
+    }
+    active.input.push({
+      type: "user",
+      message: { role: "user", content: text },
+    });
+  }
+
+  async stop(conversationId: string): Promise<void> {
+    const session = this.active.get(conversationId);
+    if (!session) return;
+    session.input.close();
+    session.abort();
+    this.cleanup(conversationId, "stopped");
+  }
+
+  private async doSpawn(conversationId: string): Promise<SessionInfo> {
+    const conversation = this.db
+      .prepare<ConversationRow, [string]>(
+        "SELECT id, worktree_path FROM conversations WHERE id = ?",
+      )
+      .get(conversationId);
+    if (!conversation) {
+      throw new SessionStartError(
+        "conversation_not_found",
+        `No conversation with id "${conversationId}"`,
+      );
+    }
+
+    const conflicting = this.db
+      .prepare<{ id: string }, [string, string]>(
+        `SELECT c.id AS id FROM session_ledger sl
+         JOIN conversations c ON c.id = sl.conversation_id
+         WHERE c.worktree_path = ? AND c.id != ?`,
+      )
+      .get(conversation.worktree_path, conversationId);
+    if (conflicting) {
+      throw new SessionStartError(
+        "worktree_in_use",
+        `Worktree "${conversation.worktree_path}" is owned by another active conversation`,
+      );
+    }
+    for (const session of this.active.values()) {
+      if (
+        session.worktree_path === conversation.worktree_path &&
+        session.conversation_id !== conversationId
+      ) {
+        throw new SessionStartError(
+          "worktree_in_use",
+          `Worktree "${conversation.worktree_path}" is owned by another active conversation`,
+        );
+      }
+    }
+
+    const input = new InputStream();
+    const result = this.spawner({ cwd: conversation.worktree_path, input });
+
+    const initState: {
+      resolve: ((info: SessionInfo) => void) | null;
+      reject: ((err: unknown) => void) | null;
+    } = { resolve: null, reject: null };
+    const initPromise = new Promise<SessionInfo>((resolve, reject) => {
+      initState.resolve = resolve;
+      initState.reject = reject;
+    });
+
+    const session: ActiveSession = {
+      conversation_id: conversationId,
+      worktree_path: conversation.worktree_path,
+      sdk_session_id: "",
+      host_pid: this.hostPid,
+      input,
+      abort: result.abort,
+    };
+
+    void (async () => {
+      try {
+        for await (const message of result.iterator) {
+          if (message.type === "system" && (message as { subtype?: string }).subtype === "init") {
+            const sdkSessionId = (message as { session_id: string }).session_id;
+            session.sdk_session_id = sdkSessionId;
+            this.active.set(conversationId, session);
+            this.db.run(
+              `INSERT OR REPLACE INTO session_ledger
+                 (conversation_id, sdk_session_id, host_pid, started_at)
+               VALUES (?, ?, ?, ?)`,
+              [conversationId, sdkSessionId, this.hostPid, new Date().toISOString()],
+            );
+            this.db.run(
+              "UPDATE conversations SET session_id = ?, last_active_at = ? WHERE id = ?",
+              [sdkSessionId, new Date().toISOString(), conversationId],
+            );
+            const initEvent: SessionEvent = {
+              kind: "session_init",
+              sdk_session_id: sdkSessionId,
+            };
+            this.broadcast(conversationId, initEvent);
+            const r = initState.resolve;
+            initState.resolve = null;
+            r?.({
+              conversation_id: conversationId,
+              sdk_session_id: sdkSessionId,
+              host_pid: this.hostPid,
+            });
+            continue;
+          }
+
+          const event = normalizeMessage(message);
+          if (event) this.broadcast(conversationId, event);
+        }
+        this.cleanup(conversationId, "ended");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const r = initState.resolve;
+        const j = initState.reject;
+        initState.resolve = null;
+        initState.reject = null;
+        if (r) {
+          j?.(err);
+        } else {
+          this.broadcast(conversationId, { kind: "error", message });
+        }
+        this.cleanup(conversationId, "error");
+      }
+    })();
+
+    return initPromise;
+  }
+
+  private broadcast(conversationId: string, event: SessionEvent): void {
+    let buffer = this.buffered.get(conversationId);
+    if (!buffer) {
+      buffer = [];
+      this.buffered.set(conversationId, buffer);
+    }
+    buffer.push(event);
+    const group = this.subscribers.get(conversationId);
+    if (!group) return;
+    for (const listener of group) {
+      try {
+        listener(event);
+      } catch {
+        // listener errors must not interrupt other listeners
+      }
+    }
+  }
+
+  private cleanup(conversationId: string, reason: string): void {
+    const session = this.active.get(conversationId);
+    if (!session) return;
+    this.active.delete(conversationId);
+    this.db.run("DELETE FROM session_ledger WHERE conversation_id = ?", [conversationId]);
+    this.broadcast(conversationId, { kind: "session_end", reason });
+    this.buffered.delete(conversationId);
+  }
+}
+
+function normalizeMessage(message: SpawnedSDKMessage): SessionEvent | null {
+  if (message.type === "assistant") {
+    const content = message.message.content;
+    if (!Array.isArray(content)) return null;
+    const blocks: AssistantBlock[] = [];
+    for (const block of content) {
+      if (!isObject(block)) continue;
+      if (block.type === "text" && typeof block.text === "string") {
+        blocks.push({ type: "text", text: block.text });
+      } else if (block.type === "thinking" && typeof block.thinking === "string") {
+        blocks.push({ type: "thinking", text: block.thinking });
+      } else if (
+        block.type === "tool_use" &&
+        typeof block.id === "string" &&
+        typeof block.name === "string"
+      ) {
+        const input = isObject(block.input) ? block.input : {};
+        blocks.push({ type: "tool_use", id: block.id, name: block.name, input });
+      }
+    }
+    if (blocks.length === 0) return null;
+    return {
+      kind: "assistant_message",
+      uuid: message.uuid,
+      ts: new Date().toISOString(),
+      blocks,
+    };
+  }
+
+  if (message.type === "user") {
+    const content = message.message.content;
+    if (!Array.isArray(content)) return null;
+    const toolResult = content.find(
+      (block): block is Record<string, unknown> => isObject(block) && block.type === "tool_result",
+    );
+    if (!toolResult) return null;
+    const inner = toolResult.content;
+    let text: string;
+    if (typeof inner === "string") {
+      text = inner;
+    } else if (Array.isArray(inner)) {
+      text = inner.map((b) => (isObject(b) && typeof b.text === "string" ? b.text : "")).join("");
+    } else {
+      text = "";
+    }
+    return {
+      kind: "tool_result",
+      uuid: message.uuid,
+      ts: new Date().toISOString(),
+      tool_use_id: typeof toolResult.tool_use_id === "string" ? toolResult.tool_use_id : "",
+      content: text,
+      is_error: toolResult.is_error === true,
+    };
+  }
+
+  if (message.type === "system") {
+    const subtype = (message as { subtype?: string }).subtype ?? "";
+    const text = (message as { content?: string }).content ?? "";
+    return {
+      kind: "system",
+      uuid: message.uuid,
+      ts: new Date().toISOString(),
+      subtype,
+      text,
+    };
+  }
+
+  return null;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/server/sessions/sdk-spawner.ts
+++ b/server/sessions/sdk-spawner.ts
@@ -1,0 +1,60 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import type { SpawnedSDKMessage, Spawner, SpawnInputMessage } from "./types.ts";
+
+export const sdkSpawner: Spawner = ({ cwd, input }) => {
+  const abortController = new AbortController();
+
+  const sdkInput = {
+    [Symbol.asyncIterator](): AsyncIterator<{
+      type: "user";
+      message: { role: "user"; content: string };
+      session_id?: string;
+    }> {
+      const inner = input[Symbol.asyncIterator]();
+      return {
+        async next() {
+          const result = await inner.next();
+          if (result.done) {
+            return { value: undefined as never, done: true };
+          }
+          return { value: result.value as SpawnInputMessage, done: false };
+        },
+      };
+    },
+  } as unknown as Parameters<typeof query>[0]["prompt"];
+
+  const q = query({
+    prompt: sdkInput,
+    options: {
+      cwd,
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+      settingSources: ["project", "user"],
+      abortController,
+      env: {
+        ...process.env,
+        CLAUDE_AGENT_SDK_CLIENT_APP: "claude-remote/0.1",
+      },
+    },
+  });
+
+  const iterator: AsyncIterable<SpawnedSDKMessage> = {
+    [Symbol.asyncIterator](): AsyncIterator<SpawnedSDKMessage> {
+      const inner = q[Symbol.asyncIterator]();
+      return {
+        async next() {
+          const result = await inner.next();
+          if (result.done) {
+            return { value: undefined as unknown as SpawnedSDKMessage, done: true };
+          }
+          return { value: result.value as unknown as SpawnedSDKMessage, done: false };
+        },
+      };
+    },
+  };
+
+  return {
+    iterator,
+    abort: () => abortController.abort(),
+  };
+};

--- a/server/sessions/types.ts
+++ b/server/sessions/types.ts
@@ -1,0 +1,75 @@
+import type { AssistantBlock } from "../transcript/reader.ts";
+
+export type SessionEvent =
+  | { kind: "session_init"; sdk_session_id: string }
+  | { kind: "user_message"; uuid: string; ts: string; text: string }
+  | { kind: "assistant_message"; uuid: string; ts: string; blocks: AssistantBlock[] }
+  | {
+      kind: "tool_result";
+      uuid: string;
+      ts: string;
+      tool_use_id: string;
+      content: string;
+      is_error: boolean;
+    }
+  | { kind: "system"; uuid: string; ts: string; subtype: string; text: string }
+  | { kind: "error"; message: string }
+  | { kind: "session_end"; reason: string };
+
+export type SpawnInputMessage = {
+  type: "user";
+  message: { role: "user"; content: string };
+};
+
+export type SpawnInput = AsyncIterable<SpawnInputMessage>;
+
+export type SpawnedSDKMessage =
+  | {
+      type: "system";
+      subtype: "init";
+      uuid: string;
+      session_id: string;
+      [key: string]: unknown;
+    }
+  | {
+      type: "system";
+      subtype: string;
+      uuid: string;
+      session_id: string;
+      content?: string;
+      [key: string]: unknown;
+    }
+  | {
+      type: "assistant";
+      uuid: string;
+      session_id: string;
+      message: { content: unknown };
+      [key: string]: unknown;
+    }
+  | {
+      type: "user";
+      uuid: string;
+      session_id: string;
+      message: { role: string; content: unknown };
+      [key: string]: unknown;
+    }
+  | {
+      type: "result";
+      uuid: string;
+      session_id: string;
+      [key: string]: unknown;
+    };
+
+export type SpawnResult = {
+  iterator: AsyncIterable<SpawnedSDKMessage>;
+  abort: () => void;
+};
+
+export type SpawnOptions = {
+  cwd: string;
+  input: SpawnInput;
+};
+
+export type Spawner = (options: SpawnOptions) => SpawnResult;
+
+export type Listener = (event: SessionEvent) => void;

--- a/server/transcript/reader.ts
+++ b/server/transcript/reader.ts
@@ -1,0 +1,193 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { stat } from "node:fs/promises";
+
+function defaultHome(): string {
+  return process.env.HOME ?? homedir();
+}
+
+export type AssistantBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
+
+export type TranscriptMessage =
+  | {
+      kind: "user_message";
+      uuid: string;
+      ts: string;
+      text: string;
+    }
+  | {
+      kind: "assistant_message";
+      uuid: string;
+      ts: string;
+      blocks: AssistantBlock[];
+    }
+  | {
+      kind: "tool_result";
+      uuid: string;
+      ts: string;
+      tool_use_id: string;
+      content: string;
+      is_error: boolean;
+    }
+  | {
+      kind: "system";
+      uuid: string;
+      ts: string;
+      subtype: string;
+      text: string;
+    };
+
+export type TranscriptLocation = {
+  cwd: string;
+  sessionId: string;
+};
+
+export function sanitizeProjectKey(cwd: string): string {
+  return cwd.replace(/\//g, "-");
+}
+
+export function transcriptPath(location: TranscriptLocation): string {
+  return join(
+    defaultHome(),
+    ".claude",
+    "projects",
+    sanitizeProjectKey(location.cwd),
+    `${location.sessionId}.jsonl`,
+  );
+}
+
+export async function readTranscript(location: TranscriptLocation): Promise<TranscriptMessage[]> {
+  const path = transcriptPath(location);
+  const exists = await stat(path).catch(() => null);
+  if (!exists?.isFile()) return [];
+
+  const file = Bun.file(path);
+  const text = await file.text();
+  const messages: TranscriptMessage[] = [];
+  for (const line of text.split("\n")) {
+    const message = parseLine(line);
+    if (message) messages.push(message);
+  }
+  return messages;
+}
+
+function parseLine(line: string): TranscriptMessage | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return null;
+  let row: unknown;
+  try {
+    row = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!isObject(row)) return null;
+  if (row.isSidechain === true) return null;
+  if (row.type === "file-history-snapshot") return null;
+  if (row.isMeta === true) return null;
+
+  const uuid = typeof row.uuid === "string" ? row.uuid : "";
+  const ts = typeof row.timestamp === "string" ? row.timestamp : "";
+  if (!uuid) return null;
+
+  if (row.type === "user") return parseUserRow(row, uuid, ts);
+  if (row.type === "assistant") return parseAssistantRow(row, uuid, ts);
+  if (row.type === "system") return parseSystemRow(row, uuid, ts);
+  return null;
+}
+
+function parseUserRow(
+  row: Record<string, unknown>,
+  uuid: string,
+  ts: string,
+): TranscriptMessage | null {
+  const message = isObject(row.message) ? row.message : null;
+  if (!message) return null;
+  const content = message.content;
+
+  if (typeof content === "string") {
+    return { kind: "user_message", uuid, ts, text: content };
+  }
+
+  if (Array.isArray(content)) {
+    const toolResult = content.find(
+      (block): block is Record<string, unknown> => isObject(block) && block.type === "tool_result",
+    );
+    if (toolResult) {
+      const inner = toolResult.content;
+      let text: string;
+      if (typeof inner === "string") {
+        text = inner;
+      } else if (Array.isArray(inner)) {
+        text = inner.map((b) => (isObject(b) && typeof b.text === "string" ? b.text : "")).join("");
+      } else {
+        text = "";
+      }
+      const toolUseId = typeof toolResult.tool_use_id === "string" ? toolResult.tool_use_id : "";
+      return {
+        kind: "tool_result",
+        uuid,
+        ts,
+        tool_use_id: toolUseId,
+        content: text,
+        is_error: toolResult.is_error === true,
+      };
+    }
+
+    const text = content
+      .map((b) => (isObject(b) && b.type === "text" && typeof b.text === "string" ? b.text : ""))
+      .join("");
+    if (text.length === 0) return null;
+    return { kind: "user_message", uuid, ts, text };
+  }
+
+  return null;
+}
+
+function parseAssistantRow(
+  row: Record<string, unknown>,
+  uuid: string,
+  ts: string,
+): TranscriptMessage | null {
+  const message = isObject(row.message) ? row.message : null;
+  if (!message) return null;
+  const content = message.content;
+  if (!Array.isArray(content)) return null;
+
+  const blocks: AssistantBlock[] = [];
+  for (const block of content) {
+    if (!isObject(block)) continue;
+    if (block.type === "text" && typeof block.text === "string") {
+      blocks.push({ type: "text", text: block.text });
+    } else if (block.type === "thinking" && typeof block.thinking === "string") {
+      blocks.push({ type: "thinking", text: block.thinking });
+    } else if (
+      block.type === "tool_use" &&
+      typeof block.id === "string" &&
+      typeof block.name === "string"
+    ) {
+      const input = isObject(block.input) ? block.input : {};
+      blocks.push({ type: "tool_use", id: block.id, name: block.name, input });
+    }
+  }
+
+  if (blocks.length === 0) return null;
+  return { kind: "assistant_message", uuid, ts, blocks };
+}
+
+function parseSystemRow(
+  row: Record<string, unknown>,
+  uuid: string,
+  ts: string,
+): TranscriptMessage | null {
+  const subtype = typeof row.subtype === "string" ? row.subtype : "";
+  const text = typeof row.content === "string" ? row.content : "";
+  if (subtype === "" && text === "") return null;
+  return { kind: "system", uuid, ts, subtype, text };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/server/ws/transport.ts
+++ b/server/ws/transport.ts
@@ -1,0 +1,101 @@
+import type { ServerWebSocket } from "bun";
+import type { SessionManager } from "../sessions/manager.ts";
+import type { SessionEvent } from "../sessions/types.ts";
+
+export type WsClientMessage =
+  | { kind: "user_message"; text: string }
+  | { kind: "stop" }
+  | { kind: "ping" };
+
+export type WsServerMessage =
+  | SessionEvent
+  | { kind: "ping" }
+  | { kind: "pong" }
+  | { kind: "ready"; conversation_id: string };
+
+export type WsAttachment = {
+  conversationId: string;
+  unsubscribe?: () => void;
+  heartbeat?: ReturnType<typeof setInterval>;
+};
+
+const HEARTBEAT_INTERVAL_MS = 20_000;
+
+export function attachWebSocket(
+  ws: ServerWebSocket<WsAttachment>,
+  conversationId: string,
+  manager: SessionManager,
+): WsAttachment {
+  const send = (message: WsServerMessage): void => {
+    try {
+      ws.send(JSON.stringify(message));
+    } catch {
+      // socket may be closed mid-send
+    }
+  };
+
+  const unsubscribe = manager.subscribe(conversationId, send);
+  for (const event of manager.bufferedEvents(conversationId)) {
+    send(event);
+  }
+  send({ kind: "ready", conversation_id: conversationId });
+
+  const heartbeat = setInterval(() => {
+    send({ kind: "ping" });
+  }, HEARTBEAT_INTERVAL_MS);
+
+  return { conversationId, unsubscribe, heartbeat };
+}
+
+export function detachWebSocket(attachment: WsAttachment): void {
+  if (attachment.heartbeat !== undefined) clearInterval(attachment.heartbeat);
+  attachment.unsubscribe?.();
+}
+
+export function parseClientMessage(raw: string | Buffer): WsClientMessage | null {
+  let text: string;
+  if (typeof raw === "string") {
+    text = raw;
+  } else {
+    text = raw.toString("utf8");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (obj.kind === "user_message" && typeof obj.text === "string") {
+    return { kind: "user_message", text: obj.text };
+  }
+  if (obj.kind === "stop") return { kind: "stop" };
+  if (obj.kind === "ping") return { kind: "ping" };
+  return null;
+}
+
+export async function handleClientMessage(
+  message: WsClientMessage,
+  conversationId: string,
+  manager: SessionManager,
+  ws: ServerWebSocket<WsAttachment>,
+): Promise<void> {
+  if (message.kind === "user_message") {
+    try {
+      await manager.send(conversationId, message.text);
+    } catch (err) {
+      const text = err instanceof Error ? err.message : String(err);
+      ws.send(JSON.stringify({ kind: "error", message: text }));
+    }
+    return;
+  }
+  if (message.kind === "stop") {
+    await manager.stop(conversationId);
+    return;
+  }
+  if (message.kind === "ping") {
+    ws.send(JSON.stringify({ kind: "pong" }));
+    return;
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -91,3 +91,41 @@ export async function listConversations(projectId: string): Promise<Conversation
   const data = await unwrap<{ conversations: Conversation[] }>(res);
   return data.conversations;
 }
+
+export type AssistantBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
+
+export type TranscriptMessage =
+  | { kind: "user_message"; uuid: string; ts: string; text: string }
+  | { kind: "assistant_message"; uuid: string; ts: string; blocks: AssistantBlock[] }
+  | {
+      kind: "tool_result";
+      uuid: string;
+      ts: string;
+      tool_use_id: string;
+      content: string;
+      is_error: boolean;
+    }
+  | { kind: "system"; uuid: string; ts: string; subtype: string; text: string };
+
+export async function getConversation(id: string): Promise<Conversation> {
+  const res = await fetch(`/api/conversations/${encodeURIComponent(id)}`);
+  return unwrap<Conversation>(res);
+}
+
+export async function getConversationMessages(id: string): Promise<TranscriptMessage[]> {
+  const res = await fetch(`/api/conversations/${encodeURIComponent(id)}/messages`);
+  const data = await unwrap<{ messages: TranscriptMessage[] }>(res);
+  return data.messages;
+}
+
+export async function sendConversationMessage(id: string, text: string): Promise<void> {
+  const res = await fetch(`/api/conversations/${encodeURIComponent(id)}/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  await unwrap<{ ok: true }>(res);
+}

--- a/src/lib/conversation-ws.ts
+++ b/src/lib/conversation-ws.ts
@@ -1,0 +1,112 @@
+import type { AssistantBlock } from "./api";
+
+export type WsServerEvent =
+  | { kind: "ready"; conversation_id: string }
+  | { kind: "session_init"; sdk_session_id: string }
+  | { kind: "user_message"; uuid: string; ts: string; text: string }
+  | { kind: "assistant_message"; uuid: string; ts: string; blocks: AssistantBlock[] }
+  | {
+      kind: "tool_result";
+      uuid: string;
+      ts: string;
+      tool_use_id: string;
+      content: string;
+      is_error: boolean;
+    }
+  | { kind: "system"; uuid: string; ts: string; subtype: string; text: string }
+  | { kind: "error"; message: string }
+  | { kind: "session_end"; reason: string }
+  | { kind: "ping" }
+  | { kind: "pong" };
+
+export type ConnectionState = "connecting" | "open" | "closed";
+
+export type ConversationWsHandlers = {
+  onEvent: (event: WsServerEvent) => void;
+  onState: (state: ConnectionState) => void;
+};
+
+export type ConversationWs = {
+  send(text: string): void;
+  close(): void;
+};
+
+const INITIAL_BACKOFF_MS = 250;
+const MAX_BACKOFF_MS = 5_000;
+
+export function connectConversationWs(
+  conversationId: string,
+  handlers: ConversationWsHandlers,
+): ConversationWs {
+  let socket: WebSocket | null = null;
+  let backoff = INITIAL_BACKOFF_MS;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let closedByUser = false;
+
+  const open = (): void => {
+    if (closedByUser) return;
+    handlers.onState("connecting");
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${protocol}//${window.location.host}/api/conversations/${encodeURIComponent(
+      conversationId,
+    )}/ws`;
+    const ws = new WebSocket(url);
+    socket = ws;
+
+    ws.addEventListener("open", () => {
+      backoff = INITIAL_BACKOFF_MS;
+      handlers.onState("open");
+    });
+
+    ws.addEventListener("message", (event) => {
+      try {
+        const parsed = JSON.parse(event.data) as WsServerEvent;
+        if (parsed.kind === "ping") {
+          ws.send(JSON.stringify({ kind: "ping" }));
+          return;
+        }
+        handlers.onEvent(parsed);
+      } catch {
+        // ignore malformed
+      }
+    });
+
+    ws.addEventListener("close", () => {
+      socket = null;
+      if (closedByUser) {
+        handlers.onState("closed");
+        return;
+      }
+      handlers.onState("closed");
+      reconnectTimer = setTimeout(() => {
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+        open();
+      }, backoff);
+    });
+
+    ws.addEventListener("error", () => {
+      // close handler will run; nothing else to do
+    });
+  };
+
+  open();
+
+  return {
+    send(text: string): void {
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ kind: "user_message", text }));
+      }
+    },
+    close(): void {
+      closedByUser = true;
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (socket) {
+        socket.close();
+        socket = null;
+      }
+    },
+  };
+}

--- a/src/routes/conversations.$conversationId.tsx
+++ b/src/routes/conversations.$conversationId.tsx
@@ -1,0 +1,366 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronLeft, GitBranch, Loader2, SendHorizonal, Wifi, WifiOff } from "lucide-react";
+import { cn } from "../lib/cn";
+import {
+  ApiRequestError,
+  getConversation,
+  getConversationMessages,
+  sendConversationMessage,
+  type AssistantBlock,
+  type Conversation,
+  type TranscriptMessage,
+} from "../lib/api";
+import {
+  connectConversationWs,
+  type ConnectionState,
+  type ConversationWs,
+  type WsServerEvent,
+} from "../lib/conversation-ws";
+
+export const Route = createFileRoute("/conversations/$conversationId")({
+  component: ConversationRoute,
+});
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "ok"; conversation: Conversation }
+  | { kind: "not_found" }
+  | { kind: "error"; message: string };
+
+function ConversationRoute() {
+  const { conversationId } = Route.useParams();
+  const [load, setLoad] = useState<LoadState>({ kind: "loading" });
+  const [messages, setMessages] = useState<TranscriptMessage[]>([]);
+  const [connState, setConnState] = useState<ConnectionState>("connecting");
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [errorBanner, setErrorBanner] = useState<string | null>(null);
+  const wsRef = useRef<ConversationWs | null>(null);
+  const seenUuids = useRef<Set<string>>(new Set());
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [conversation, history] = await Promise.all([
+          getConversation(conversationId),
+          getConversationMessages(conversationId),
+        ]);
+        if (cancelled) return;
+        seenUuids.current = new Set(history.map((m) => m.uuid));
+        setLoad({ kind: "ok", conversation });
+        setMessages(history);
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof ApiRequestError && err.status === 404) {
+          setLoad({ kind: "not_found" });
+          return;
+        }
+        setLoad({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Failed to load conversation",
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationId]);
+
+  useEffect(() => {
+    const ws = connectConversationWs(conversationId, {
+      onState: setConnState,
+      onEvent: (event) => handleWsEvent(event),
+    });
+    wsRef.current = ws;
+    return () => {
+      ws.close();
+      wsRef.current = null;
+    };
+
+    function handleWsEvent(event: WsServerEvent): void {
+      if (event.kind === "ready" || event.kind === "session_init" || event.kind === "pong") return;
+      if (event.kind === "session_end") return;
+      if (event.kind === "error") {
+        setErrorBanner(event.message);
+        return;
+      }
+      if (
+        event.kind === "user_message" ||
+        event.kind === "assistant_message" ||
+        event.kind === "tool_result" ||
+        event.kind === "system"
+      ) {
+        const uuid = event.uuid;
+        if (!uuid) return;
+        if (seenUuids.current.has(uuid)) return;
+        seenUuids.current.add(uuid);
+        setMessages((prev) => [...prev, event as TranscriptMessage]);
+      }
+    }
+  }, [conversationId]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages]);
+
+  const handleSend = useCallback(async () => {
+    const text = draft.trim();
+    if (text.length === 0 || sending) return;
+    setSending(true);
+    setErrorBanner(null);
+    try {
+      await sendConversationMessage(conversationId, text);
+      setDraft("");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Send failed";
+      setErrorBanner(message);
+    } finally {
+      setSending(false);
+    }
+  }, [conversationId, draft, sending]);
+
+  return (
+    <main className="mx-auto flex h-dvh max-w-screen-md flex-col px-5 py-4">
+      <header className="mb-3 flex items-center justify-between gap-3">
+        {load.kind === "ok" ? (
+          <Link
+            to="/projects/$projectId"
+            params={{ projectId: load.conversation.project_id }}
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground transition hover:text-foreground"
+          >
+            <ChevronLeft className="size-4" aria-hidden />
+            <span>Back</span>
+          </Link>
+        ) : (
+          <Link
+            to="/"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground transition hover:text-foreground"
+          >
+            <ChevronLeft className="size-4" aria-hidden />
+            <span>Projects</span>
+          </Link>
+        )}
+        <ConnectionPill state={connState} />
+      </header>
+
+      {load.kind === "loading" && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+      {load.kind === "not_found" && (
+        <div className="rounded-2xl border border-border/60 bg-card p-6 text-sm">
+          <h1 className="text-lg font-semibold">Conversation not found</h1>
+        </div>
+      )}
+
+      {load.kind === "error" && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {load.message}
+        </div>
+      )}
+
+      {load.kind === "ok" && (
+        <>
+          <div className="mb-3">
+            <h1 className="truncate text-lg font-semibold">{load.conversation.title}</h1>
+            <div className="mt-1 inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+              <GitBranch className="size-3" aria-hidden />
+              <span className="font-mono">{load.conversation.branch}</span>
+            </div>
+          </div>
+
+          {errorBanner && (
+            <div className="mb-3 rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-2 text-sm text-destructive">
+              {errorBanner}
+            </div>
+          )}
+
+          <div
+            ref={scrollRef}
+            className="flex-1 overflow-y-auto rounded-2xl border border-border/60 bg-card p-4"
+          >
+            {messages.length === 0 ? (
+              <p className="text-center text-sm text-muted-foreground">
+                Send a message to start the conversation.
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-3">
+                {messages.map((m) => (
+                  <MessageItem key={m.uuid} message={m} />
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <Composer
+            value={draft}
+            onChange={setDraft}
+            onSend={handleSend}
+            sending={sending}
+            disabled={connState !== "open"}
+          />
+        </>
+      )}
+    </main>
+  );
+}
+
+function ConnectionPill({ state }: { state: ConnectionState }) {
+  if (state === "open") {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-600 dark:text-emerald-400">
+        <Wifi className="size-3" aria-hidden />
+        <span>Live</span>
+      </span>
+    );
+  }
+  if (state === "connecting") {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+        <Loader2 className="size-3 animate-spin" aria-hidden />
+        <span>Connecting</span>
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs text-amber-600 dark:text-amber-400">
+      <WifiOff className="size-3" aria-hidden />
+      <span>Reconnecting</span>
+    </span>
+  );
+}
+
+function MessageItem({ message }: { message: TranscriptMessage }) {
+  if (message.kind === "user_message") {
+    return (
+      <li className="flex justify-end">
+        <div className="max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-primary px-3 py-2 text-sm text-primary-foreground">
+          {message.text}
+        </div>
+      </li>
+    );
+  }
+  if (message.kind === "assistant_message") {
+    return (
+      <li className="flex justify-start">
+        <div className="max-w-[85%] space-y-2 rounded-2xl rounded-bl-md bg-muted px-3 py-2 text-sm">
+          {message.blocks.map((block, idx) => (
+            <AssistantBlockView key={idx} block={block} />
+          ))}
+        </div>
+      </li>
+    );
+  }
+  if (message.kind === "tool_result") {
+    return (
+      <li className="flex justify-start">
+        <div
+          className={cn(
+            "max-w-[85%] rounded-lg border px-3 py-1.5 font-mono text-xs",
+            message.is_error
+              ? "border-destructive/40 bg-destructive/5 text-destructive"
+              : "border-border/60 bg-background/40 text-muted-foreground",
+          )}
+        >
+          <div className="mb-1 text-[10px] uppercase tracking-wide opacity-70">
+            tool result · {message.tool_use_id.slice(0, 8)}
+          </div>
+          <pre className="max-h-40 overflow-y-auto whitespace-pre-wrap break-words">
+            {truncate(message.content, 1200)}
+          </pre>
+        </div>
+      </li>
+    );
+  }
+  if (message.kind === "system" && message.text.length > 0) {
+    return (
+      <li className="flex justify-center">
+        <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+          {message.subtype}
+        </span>
+      </li>
+    );
+  }
+  return null;
+}
+
+function AssistantBlockView({ block }: { block: AssistantBlock }) {
+  if (block.type === "text") {
+    return <p className="whitespace-pre-wrap">{block.text}</p>;
+  }
+  if (block.type === "thinking") {
+    return (
+      <p className="whitespace-pre-wrap rounded-md bg-background/40 p-2 text-xs italic text-muted-foreground">
+        {block.text}
+      </p>
+    );
+  }
+  return (
+    <div className="rounded-md bg-background/40 px-2 py-1.5 font-mono text-xs">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        tool · {block.name}
+      </div>
+      <pre className="mt-1 whitespace-pre-wrap break-words text-muted-foreground">
+        {truncate(JSON.stringify(block.input, null, 2), 400)}
+      </pre>
+    </div>
+  );
+}
+
+function Composer({
+  value,
+  onChange,
+  onSend,
+  sending,
+  disabled,
+}: {
+  value: string;
+  onChange: (text: string) => void;
+  onSend: () => void;
+  sending: boolean;
+  disabled: boolean;
+}) {
+  return (
+    <form
+      className="mt-3 flex items-end gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSend();
+      }}
+    >
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            onSend();
+          }
+        }}
+        rows={2}
+        placeholder="Send a message…"
+        className="min-h-12 flex-1 resize-y rounded-2xl border border-input bg-background px-3 py-2 text-sm outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/30"
+      />
+      <button
+        type="submit"
+        disabled={sending || value.trim().length === 0 || disabled}
+        aria-label="Send message"
+        className="inline-flex size-12 shrink-0 items-center justify-center rounded-2xl bg-primary text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {sending ? (
+          <Loader2 className="size-5 animate-spin" aria-hidden />
+        ) : (
+          <SendHorizonal className="size-5" aria-hidden />
+        )}
+      </button>
+    </form>
+  );
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}\n…(truncated ${text.length - max} chars)`;
+}

--- a/src/routes/projects.$projectId.tsx
+++ b/src/routes/projects.$projectId.tsx
@@ -125,27 +125,33 @@ function ConversationCard({ conversation }: { conversation: Conversation }) {
   return (
     <li
       className={cn(
-        "flex items-start justify-between gap-3 rounded-2xl border bg-card p-4",
+        "rounded-2xl border bg-card transition hover:border-border",
         conversation.is_default ? "border-primary/40" : "border-border/60",
       )}
     >
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          {conversation.is_default && (
-            <Pin className="size-3.5 shrink-0 text-primary" aria-label="Default conversation" />
-          )}
-          <h3 className="truncate text-base font-semibold">{conversation.title}</h3>
+      <Link
+        to="/conversations/$conversationId"
+        params={{ conversationId: conversation.id }}
+        className="flex items-start justify-between gap-3 p-4"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            {conversation.is_default && (
+              <Pin className="size-3.5 shrink-0 text-primary" aria-label="Default conversation" />
+            )}
+            <h3 className="truncate text-base font-semibold">{conversation.title}</h3>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5">
+              <GitBranch className="size-3" aria-hidden />
+              <span className="font-mono">{conversation.branch}</span>
+            </span>
+            <time dateTime={conversation.last_active_at}>
+              {formatRelativeTime(conversation.last_active_at)}
+            </time>
+          </div>
         </div>
-        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
-          <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5">
-            <GitBranch className="size-3" aria-hidden />
-            <span className="font-mono">{conversation.branch}</span>
-          </span>
-          <time dateTime={conversation.last_active_at}>
-            {formatRelativeTime(conversation.last_active_at)}
-          </time>
-        </div>
-      </div>
+      </Link>
     </li>
   );
 }

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { $ } from "bun";
+import { runMigrationsFromDir } from "../server/db/migrator.ts";
+import { registerProject } from "../server/projects/registry.ts";
+import { ensureDefaultConversation } from "../server/conversations/registry.ts";
+import { SessionManager } from "../server/sessions/manager.ts";
+import type {
+  SessionEvent,
+  SpawnedSDKMessage,
+  Spawner,
+  SpawnOptions,
+  SpawnResult,
+} from "../server/sessions/types.ts";
+
+const MIGRATIONS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "server",
+  "db",
+  "migrations",
+);
+
+let tempDir: string;
+let db: Database;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "claude-remote-sessions-"));
+  db = new Database(":memory:");
+  db.exec("PRAGMA foreign_keys = ON;");
+  runMigrationsFromDir(db, MIGRATIONS_DIR);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function initRepo(path: string, initialBranch = "main") {
+  mkdirSync(path, { recursive: true });
+  await $`git -C ${path} init -b ${initialBranch}`.quiet();
+  await $`git -C ${path} config user.email test@example.com`.quiet();
+  await $`git -C ${path} config user.name Test`.quiet();
+  writeFileSync(join(path, "README.md"), "test\n");
+  await $`git -C ${path} add .`.quiet();
+  await $`git -C ${path} commit -m initial`.quiet();
+}
+
+async function makeConversation(name: string) {
+  const repo = join(tempDir, name);
+  await initRepo(repo);
+  const project = await registerProject(db, { name, repo_path: repo });
+  return ensureDefaultConversation(db, project);
+}
+
+class FakeSpawn {
+  pendingResults: Array<{
+    resolve: (result: IteratorResult<SpawnedSDKMessage>) => void;
+  }> = [];
+  queued: SpawnedSDKMessage[] = [];
+  closed = false;
+  aborted = false;
+  options: SpawnOptions;
+
+  constructor(options: SpawnOptions) {
+    this.options = options;
+  }
+
+  emit(message: SpawnedSDKMessage): void {
+    if (this.closed) return;
+    const next = this.pendingResults.shift();
+    if (next) {
+      next.resolve({ value: message, done: false });
+    } else {
+      this.queued.push(message);
+    }
+  }
+
+  end(): void {
+    this.closed = true;
+    for (const p of this.pendingResults) {
+      p.resolve({ value: undefined as unknown as SpawnedSDKMessage, done: true });
+    }
+    this.pendingResults.length = 0;
+  }
+
+  abort = (): void => {
+    this.aborted = true;
+    this.end();
+  };
+
+  iterator: AsyncIterable<SpawnedSDKMessage> = {
+    [Symbol.asyncIterator]: (): AsyncIterator<SpawnedSDKMessage> => ({
+      next: (): Promise<IteratorResult<SpawnedSDKMessage>> => {
+        const buffered = this.queued.shift();
+        if (buffered) return Promise.resolve({ value: buffered, done: false });
+        if (this.closed) {
+          return Promise.resolve({
+            value: undefined as unknown as SpawnedSDKMessage,
+            done: true,
+          });
+        }
+        return new Promise((res) => this.pendingResults.push({ resolve: res }));
+      },
+    }),
+  };
+
+  toResult(): SpawnResult {
+    return { iterator: this.iterator, abort: this.abort };
+  }
+}
+
+class SpawnerTracker {
+  spawns: FakeSpawn[] = [];
+  spawner: Spawner;
+
+  constructor() {
+    this.spawner = (options: SpawnOptions): SpawnResult => {
+      const fake = new FakeSpawn(options);
+      this.spawns.push(fake);
+      return fake.toResult();
+    };
+  }
+
+  latest(): FakeSpawn {
+    const last = this.spawns.at(-1);
+    if (!last) throw new Error("no spawn yet");
+    return last;
+  }
+}
+
+function initMessage(sessionId: string): SpawnedSDKMessage {
+  return {
+    type: "system",
+    subtype: "init",
+    uuid: `init-${sessionId}`,
+    session_id: sessionId,
+  };
+}
+
+describe("SessionManager", () => {
+  test("start spawns the SDK process and resolves with session info on init", async () => {
+    const conversation = await makeConversation("alpha");
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: () => true,
+      hostPid: 9999,
+    });
+
+    const promise = manager.start(conversation.id);
+    await Promise.resolve();
+    tracker.latest().emit(initMessage("sdk-1"));
+    const info = await promise;
+
+    expect(info.sdk_session_id).toBe("sdk-1");
+    expect(info.host_pid).toBe(9999);
+    expect(tracker.spawns).toHaveLength(1);
+
+    const ledger = db
+      .prepare<{ sdk_session_id: string; host_pid: number }, [string]>(
+        "SELECT sdk_session_id, host_pid FROM session_ledger WHERE conversation_id = ?",
+      )
+      .get(conversation.id);
+    expect(ledger?.sdk_session_id).toBe("sdk-1");
+    expect(ledger?.host_pid).toBe(9999);
+  });
+
+  test("start is idempotent for an active session", async () => {
+    const conversation = await makeConversation("idem");
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: () => true,
+      hostPid: 1000,
+    });
+
+    const first = manager.start(conversation.id);
+    tracker.latest().emit(initMessage("sdk-A"));
+    await first;
+
+    const second = await manager.start(conversation.id);
+    expect(second.sdk_session_id).toBe("sdk-A");
+    expect(tracker.spawns).toHaveLength(1);
+  });
+
+  test("concurrent start calls share a single spawn", async () => {
+    const conversation = await makeConversation("concurrent");
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: () => true,
+      hostPid: 1000,
+    });
+
+    const a = manager.start(conversation.id);
+    const b = manager.start(conversation.id);
+    await Promise.resolve();
+    tracker.latest().emit(initMessage("sdk-conc"));
+    const [resA, resB] = await Promise.all([a, b]);
+
+    expect(resA.sdk_session_id).toBe("sdk-conc");
+    expect(resB.sdk_session_id).toBe("sdk-conc");
+    expect(tracker.spawns).toHaveLength(1);
+  });
+
+  test("stale ledger entries are pruned on start", async () => {
+    const conversation = await makeConversation("stale");
+    db.run(
+      `INSERT INTO session_ledger
+         (conversation_id, sdk_session_id, host_pid, started_at)
+       VALUES (?, ?, ?, ?)`,
+      [conversation.id, "old-session", 424242, new Date().toISOString()],
+    );
+
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: (pid) => pid !== 424242,
+      hostPid: 1000,
+    });
+
+    const promise = manager.start(conversation.id);
+    await Promise.resolve();
+    tracker.latest().emit(initMessage("sdk-fresh"));
+    const info = await promise;
+
+    expect(info.sdk_session_id).toBe("sdk-fresh");
+    const ledger = db
+      .prepare<{ sdk_session_id: string }, [string]>(
+        "SELECT sdk_session_id FROM session_ledger WHERE conversation_id = ?",
+      )
+      .get(conversation.id);
+    expect(ledger?.sdk_session_id).toBe("sdk-fresh");
+  });
+
+  test("worktree exclusivity blocks a second conversation on the same worktree", async () => {
+    const a = await makeConversation("excl");
+    const repoB = join(tempDir, "excl-b");
+    await initRepo(repoB);
+    const projectB = await registerProject(db, { name: "B", repo_path: repoB });
+    const conversationB = await ensureDefaultConversation(db, projectB);
+
+    db.run("UPDATE conversations SET worktree_path = ? WHERE id = ?", [
+      a.worktree_path,
+      conversationB.id,
+    ]);
+
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: () => true,
+      hostPid: 1000,
+    });
+
+    const first = manager.start(a.id);
+    tracker.latest().emit(initMessage("sdk-A"));
+    await first;
+
+    await expect(manager.start(conversationB.id)).rejects.toMatchObject({
+      name: "SessionStartError",
+      code: "worktree_in_use",
+    });
+  });
+
+  test("subscribe never spawns; events arrive once start completes", async () => {
+    const conversation = await makeConversation("sub");
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: () => true,
+      hostPid: 1000,
+    });
+
+    const events: SessionEvent[] = [];
+    manager.subscribe(conversation.id, (e) => events.push(e));
+    expect(tracker.spawns).toHaveLength(0);
+
+    const promise = manager.start(conversation.id);
+    tracker.latest().emit(initMessage("sdk-sub"));
+    await promise;
+
+    expect(events).toEqual([{ kind: "session_init", sdk_session_id: "sdk-sub" }]);
+    expect(tracker.spawns).toHaveLength(1);
+  });
+
+  test("pruneStaleEntries removes ledger rows whose host_pid is dead", async () => {
+    const a = await makeConversation("prune-a");
+    const repoB = join(tempDir, "prune-b");
+    await initRepo(repoB);
+    const projectB = await registerProject(db, { name: "prune-b", repo_path: repoB });
+    const conversationB = await ensureDefaultConversation(db, projectB);
+
+    db.run(
+      `INSERT INTO session_ledger
+         (conversation_id, sdk_session_id, host_pid, started_at)
+       VALUES (?, ?, ?, ?), (?, ?, ?, ?)`,
+      [
+        a.id,
+        "sess-a",
+        100,
+        new Date().toISOString(),
+        conversationB.id,
+        "sess-b",
+        200,
+        new Date().toISOString(),
+      ],
+    );
+
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: (pid) => pid === 100,
+      hostPid: 100,
+    });
+
+    expect(manager.pruneStaleEntries()).toBe(1);
+
+    const remaining = db
+      .prepare<{ conversation_id: string }, []>(
+        "SELECT conversation_id FROM session_ledger ORDER BY conversation_id",
+      )
+      .all()
+      .map((r) => r.conversation_id);
+    expect(remaining).toEqual([a.id]);
+  });
+
+  test("send queues a user message; broadcasts assistant reply", async () => {
+    const conversation = await makeConversation("send");
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: () => true,
+      hostPid: 1000,
+    });
+
+    const events: SessionEvent[] = [];
+    manager.subscribe(conversation.id, (e) => events.push(e));
+
+    const promise = manager.start(conversation.id);
+    tracker.latest().emit(initMessage("sdk-send"));
+    await promise;
+
+    await manager.send(conversation.id, "Hello there");
+
+    const consumed: { type: string; content: unknown }[] = [];
+    void (async () => {
+      for await (const msg of tracker.latest().options.input) {
+        consumed.push({ type: msg.type, content: msg.message.content });
+      }
+    })();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(consumed[0]).toEqual({ type: "user", content: "Hello there" });
+
+    tracker.latest().emit({
+      type: "assistant",
+      uuid: "asst-1",
+      session_id: "sdk-send",
+      message: { content: [{ type: "text", text: "Hi!" }] },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const assistant = events.find((e) => e.kind === "assistant_message");
+    expect(assistant).toBeDefined();
+    if (assistant?.kind === "assistant_message") {
+      expect(assistant.blocks).toEqual([{ type: "text", text: "Hi!" }]);
+    }
+  });
+
+  test("stop closes input, aborts spawn, deletes ledger row, emits session_end", async () => {
+    const conversation = await makeConversation("stop");
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: () => true,
+      hostPid: 1000,
+    });
+
+    const events: SessionEvent[] = [];
+    manager.subscribe(conversation.id, (e) => events.push(e));
+
+    const promise = manager.start(conversation.id);
+    tracker.latest().emit(initMessage("sdk-stop"));
+    await promise;
+
+    await manager.stop(conversation.id);
+    await Promise.resolve();
+
+    expect(tracker.latest().aborted).toBe(true);
+    expect(events.find((e) => e.kind === "session_end")).toBeDefined();
+
+    const ledger = db
+      .prepare<{ conversation_id: string }, [string]>(
+        "SELECT conversation_id FROM session_ledger WHERE conversation_id = ?",
+      )
+      .get(conversation.id);
+    expect(ledger).toBeNull();
+  });
+});

--- a/tests/transcript-reader.test.ts
+++ b/tests/transcript-reader.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readTranscript, sanitizeProjectKey, transcriptPath } from "../server/transcript/reader.ts";
+
+let tempHome: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "claude-remote-transcripts-"));
+  originalHome = process.env.HOME;
+  process.env.HOME = tempHome;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  rmSync(tempHome, { recursive: true, force: true });
+});
+
+function writeTranscript(cwd: string, sessionId: string, lines: unknown[]): void {
+  const dir = join(tempHome, ".claude", "projects", sanitizeProjectKey(cwd));
+  mkdirSync(dir, { recursive: true });
+  const body = lines.map((l) => JSON.stringify(l)).join("\n");
+  writeFileSync(join(dir, `${sessionId}.jsonl`), body);
+}
+
+function writeRawTranscript(cwd: string, sessionId: string, raw: string): void {
+  const dir = join(tempHome, ".claude", "projects", sanitizeProjectKey(cwd));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${sessionId}.jsonl`), raw);
+}
+
+describe("Transcript Reader", () => {
+  test("sanitizeProjectKey replaces slashes with dashes", () => {
+    expect(sanitizeProjectKey("/Users/alice/code/foo")).toBe("-Users-alice-code-foo");
+  });
+
+  test("transcriptPath joins ~/.claude/projects/<sanitized>/<session>.jsonl", () => {
+    const path = transcriptPath({
+      cwd: "/Users/alice/repo",
+      sessionId: "abc-123",
+    });
+    expect(path).toBe(join(tempHome, ".claude/projects/-Users-alice-repo/abc-123.jsonl"));
+  });
+
+  test("returns [] for missing file", async () => {
+    const messages = await readTranscript({
+      cwd: "/tmp/missing",
+      sessionId: "no-such-session",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  test("returns [] for empty file", async () => {
+    writeRawTranscript("/tmp/empty", "session-1", "");
+    const messages = await readTranscript({
+      cwd: "/tmp/empty",
+      sessionId: "session-1",
+    });
+    expect(messages).toEqual([]);
+  });
+
+  test("normalizes a string-content user message", async () => {
+    writeTranscript("/repo/x", "s1", [
+      {
+        type: "user",
+        uuid: "u1",
+        timestamp: "2026-04-25T10:00:00.000Z",
+        message: { role: "user", content: "Hello" },
+      },
+    ]);
+
+    const messages = await readTranscript({ cwd: "/repo/x", sessionId: "s1" });
+    expect(messages).toEqual([
+      { kind: "user_message", uuid: "u1", ts: "2026-04-25T10:00:00.000Z", text: "Hello" },
+    ]);
+  });
+
+  test("normalizes an assistant message into text/thinking/tool_use blocks", async () => {
+    writeTranscript("/repo/x", "s2", [
+      {
+        type: "assistant",
+        uuid: "a1",
+        timestamp: "2026-04-25T10:01:00.000Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "hmm" },
+            { type: "text", text: "Hi there" },
+            { type: "tool_use", id: "t1", name: "Read", input: { path: "/x" } },
+          ],
+        },
+      },
+    ]);
+
+    const messages = await readTranscript({ cwd: "/repo/x", sessionId: "s2" });
+    expect(messages).toHaveLength(1);
+    const msg = messages[0]!;
+    expect(msg.kind).toBe("assistant_message");
+    if (msg.kind !== "assistant_message") return;
+    expect(msg.blocks).toEqual([
+      { type: "thinking", text: "hmm" },
+      { type: "text", text: "Hi there" },
+      { type: "tool_use", id: "t1", name: "Read", input: { path: "/x" } },
+    ]);
+  });
+
+  test("extracts tool_result blocks from user-message arrays", async () => {
+    writeTranscript("/repo/x", "s3", [
+      {
+        type: "user",
+        uuid: "tr1",
+        timestamp: "2026-04-25T10:02:00.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }],
+        },
+      },
+    ]);
+
+    const messages = await readTranscript({ cwd: "/repo/x", sessionId: "s3" });
+    expect(messages).toEqual([
+      {
+        kind: "tool_result",
+        uuid: "tr1",
+        ts: "2026-04-25T10:02:00.000Z",
+        tool_use_id: "t1",
+        content: "ok",
+        is_error: false,
+      },
+    ]);
+  });
+
+  test("flattens tool_result content arrays into a single text", async () => {
+    writeTranscript("/repo/x", "s4", [
+      {
+        type: "user",
+        uuid: "tr2",
+        timestamp: "2026-04-25T10:02:00.000Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t2",
+              is_error: true,
+              content: [
+                { type: "text", text: "error " },
+                { type: "text", text: "details" },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const messages = await readTranscript({ cwd: "/repo/x", sessionId: "s4" });
+    expect(messages).toEqual([
+      {
+        kind: "tool_result",
+        uuid: "tr2",
+        ts: "2026-04-25T10:02:00.000Z",
+        tool_use_id: "t2",
+        content: "error details",
+        is_error: true,
+      },
+    ]);
+  });
+
+  test("skips file-history-snapshot, sidechain, and meta rows", async () => {
+    writeTranscript("/repo/x", "s5", [
+      { type: "file-history-snapshot", uuid: "fhs1", timestamp: "2026-04-25T10:00:00.000Z" },
+      {
+        type: "user",
+        isSidechain: true,
+        uuid: "side1",
+        timestamp: "2026-04-25T10:00:01.000Z",
+        message: { role: "user", content: "subagent" },
+      },
+      {
+        type: "user",
+        isMeta: true,
+        uuid: "meta1",
+        timestamp: "2026-04-25T10:00:02.000Z",
+        message: { role: "user", content: "meta" },
+      },
+      {
+        type: "user",
+        uuid: "u1",
+        timestamp: "2026-04-25T10:00:03.000Z",
+        message: { role: "user", content: "real" },
+      },
+    ]);
+
+    const messages = await readTranscript({ cwd: "/repo/x", sessionId: "s5" });
+    expect(messages.map((m) => m.uuid)).toEqual(["u1"]);
+  });
+
+  test("tolerates malformed JSON lines and a malformed trailing line without a newline", async () => {
+    const good = JSON.stringify({
+      type: "user",
+      uuid: "u1",
+      timestamp: "t",
+      message: { role: "user", content: "hello" },
+    });
+    const raw = `${good}\nnot json\n{"this is": "missing fields"}\nstill bad`;
+    writeRawTranscript("/repo/x", "s6", raw);
+
+    const messages = await readTranscript({ cwd: "/repo/x", sessionId: "s6" });
+    expect(messages.map((m) => m.uuid)).toEqual(["u1"]);
+  });
+
+  test("preserves order across mixed message kinds", async () => {
+    writeTranscript("/repo/x", "s7", [
+      {
+        type: "user",
+        uuid: "u1",
+        timestamp: "2026-04-25T10:00:00.000Z",
+        message: { role: "user", content: "Run something" },
+      },
+      {
+        type: "assistant",
+        uuid: "a1",
+        timestamp: "2026-04-25T10:00:01.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t1", name: "Bash", input: { cmd: "ls" } }],
+        },
+      },
+      {
+        type: "user",
+        uuid: "tr1",
+        timestamp: "2026-04-25T10:00:02.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "a b c" }],
+        },
+      },
+      {
+        type: "assistant",
+        uuid: "a2",
+        timestamp: "2026-04-25T10:00:03.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+        },
+      },
+    ]);
+
+    const messages = await readTranscript({ cwd: "/repo/x", sessionId: "s7" });
+    expect(messages.map((m) => `${m.kind}:${m.uuid}`)).toEqual([
+      "user_message:u1",
+      "assistant_message:a1",
+      "tool_result:tr1",
+      "assistant_message:a2",
+    ]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       "/api": {
         target: `http://127.0.0.1:${apiPort}`,
         changeOrigin: true,
+        ws: true,
       },
     },
   },


### PR DESCRIPTION
Closes #5.

## Summary

End-to-end chat path is now wired: send a message from the web app, see Claude stream a response back over WebSockets, and reload the page to see history rendered straight from the canonical `~/.claude/projects/` JSONL.

- **Session Manager** (`server/sessions/manager.ts`) — `start`/`send`/`stop`/`subscribe` plus `pruneStaleEntries`. Spawner is injected, the default uses `@anthropic-ai/claude-agent-sdk` with `permissionMode: "bypassPermissions"`, `allowDangerouslySkipPermissions: true`, and `settingSources: ["project", "user"]`. Enforces single-process-per-conversation via the `session_ledger` plus an in-memory inflight map, single-process-per-worktree via the ledger ⨯ conversations join, and prunes ledger rows whose `host_pid` is dead on server start.
- **Transcript Reader** (`server/transcript/reader.ts`) — normalizes the on-disk JSONL into `user_message`/`assistant_message`/`tool_result`/`system` kinds. Tolerates malformed lines, missing files, empty files, sidechain rows, and meta rows.
- **WebSocket transport** (`server/ws/transport.ts`) — first-class message kinds (`assistant_message`/`tool_use`/`tool_result`/`system`/`user_message`/`error`/`session_init`/`session_end` plus `ping`/`pong`/`ready`). 20s server heartbeat with `idleTimeout: 30`. Subscribe path never spawns.
- **HTTP + WS routes** — `GET /api/conversations/:id`, `GET /api/conversations/:id/messages` (history), `POST /api/conversations/:id/messages` (send; lazy-spawns), `WS /api/conversations/:id/ws` (subscribe). Wired in both `server/dev-api.ts` and prod `index.ts`. Vite dev proxy forwards WS.
- **Web client** (`src/routes/conversations.$conversationId.tsx` + `src/lib/conversation-ws.ts`) — renders history, streams assistant text + tool calls inline, and reconnects with exponential backoff capped at 5s. Connection pill shows live/connecting/reconnecting.

51 tests pass (20 new for Transcript Reader + Session Manager). `typecheck`, `lint`, and `format:check` are all clean.

WS reconnect is pure subscription — it never spawns a new SDK process. WS disconnect leaves the in-flight SDK process running; on reconnect, the client rejoins the broadcast group and continues receiving events.

## Test plan

- [x] `bun run test` — all 51 specs pass.
- [x] `bun run typecheck`, `bun run lint`, `bun run format:check` — clean.
- [x] `bun run dev`, open the project view of an already-registered project, tap into the default conversation, send a message, and watch the response stream in.
- [x] Reload the conversation tab mid-turn — history renders and the in-flight reply continues to stream once the WS reconnects.
- [x] Send a message from one browser tab, open the same conversation in a second tab — both see the streaming reply.
- [x] Restart the dev server while a session is "running" — on next start, the stale `session_ledger` entry is pruned (`[dev-api] pruned N stale session_ledger entries`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)