### PR TITLE
Slice 5: worktree creation flow — Worktree Manager + new conversation modes

### DIFF
--- a/server/api/handler.ts
+++ b/server/api/handler.ts
@@ -8,10 +8,13 @@ import {
   type Project,
 } from "../projects/registry.ts";
 import {
+  ConversationValidationError,
+  createConversation,
   ensureDefaultConversation,
   getConversation,
   listConversations,
   type Conversation,
+  type CreateConversationInput,
 } from "../conversations/registry.ts";
 import type { SessionManager } from "../sessions/manager.ts";
 import { SessionStartError } from "../sessions/manager.ts";
@@ -125,6 +128,73 @@ async function handleListProjectConversations(
   return json(200, { conversations });
 }
 
+function parseCreateConversationInput(body: Record<string, unknown>):
+  | CreateConversationInput
+  | {
+      error: { code: string; field: string; message: string };
+    } {
+  const mode = body.mode;
+  if (mode === "main") return { mode: "main" };
+  if (mode === "new-worktree" || mode === "existing-branch") {
+    if (typeof body.branch !== "string") {
+      return {
+        error: {
+          code: "invalid_body",
+          field: "branch",
+          message: "branch is required for this mode",
+        },
+      };
+    }
+    if (mode === "new-worktree") {
+      const baseBranch = typeof body.base_branch === "string" ? body.base_branch : undefined;
+      return { mode, branch: body.branch, base_branch: baseBranch };
+    }
+    return { mode, branch: body.branch };
+  }
+  return {
+    error: {
+      code: "invalid_body",
+      field: "mode",
+      message: 'mode must be "main", "new-worktree", or "existing-branch"',
+    },
+  };
+}
+
+async function handleCreateProjectConversation(
+  projectId: string,
+  req: Request,
+  ctx: ApiContext,
+): Promise<Response> {
+  const project = getProject(ctx.db, projectId);
+  if (!project) {
+    return json(404, {
+      error: { code: "not_found", message: `No project with id "${projectId}"` },
+    });
+  }
+  const body = await readJson(req);
+  if (!isPlainObject(body)) {
+    return json(400, {
+      error: { code: "invalid_body", message: "Request body must be a JSON object" },
+    });
+  }
+  const parsed = parseCreateConversationInput(body);
+  if ("error" in parsed) return json(400, { error: parsed.error });
+
+  await ensureDefaultConversation(ctx.db, project);
+  try {
+    const conversation = await createConversation(ctx.db, project, parsed);
+    return json(201, conversation);
+  } catch (err) {
+    if (err instanceof ConversationValidationError) {
+      const status = err.code === "worktree_in_use" ? 409 : 400;
+      return json(status, {
+        error: { code: err.code, field: err.field, message: err.message },
+      });
+    }
+    throw err;
+  }
+}
+
 function handleGetConversation(id: string, ctx: ApiContext): Response {
   const conversation = getConversation(ctx.db, id);
   if (!conversation) {
@@ -199,6 +269,8 @@ export async function handleApi(req: Request, ctx: ApiContext): Promise<Response
   const conversationsProjectId = projectConversationsMatch(url.pathname);
   if (conversationsProjectId) {
     if (req.method === "GET") return handleListProjectConversations(conversationsProjectId, ctx);
+    if (req.method === "POST")
+      return handleCreateProjectConversation(conversationsProjectId, req, ctx);
     return json(405, {
       error: {
         code: "method_not_allowed",

--- a/server/conversations/registry.ts
+++ b/server/conversations/registry.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
 import type { Database } from "bun:sqlite";
 import { detectCurrentBranch } from "../git.ts";
 import type { Project } from "../projects/registry.ts";
+import { createWorktree, WorktreeError } from "../worktrees/manager.ts";
 
 export type ConversationStatus = "active" | "orphaned" | "archived";
 
@@ -27,6 +29,32 @@ export class ConversationNotFoundError extends Error {
     this.id = id;
   }
 }
+
+export type ConversationValidationCode =
+  | "invalid_mode"
+  | "branch_required"
+  | "worktree_in_use"
+  | "worktree_create_failed";
+
+export class ConversationValidationError extends Error {
+  readonly code: ConversationValidationCode;
+  readonly field: "mode" | "branch" | "base_branch" | null;
+  constructor(
+    code: ConversationValidationCode,
+    field: "mode" | "branch" | "base_branch" | null,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ConversationValidationError";
+    this.code = code;
+    this.field = field;
+  }
+}
+
+export type CreateConversationInput =
+  | { mode: "main" }
+  | { mode: "new-worktree"; branch: string; base_branch?: string }
+  | { mode: "existing-branch"; branch: string };
 
 const CONVERSATION_COLUMNS =
   "id, project_id, worktree_path, branch, session_id, title, color, is_default, status, created_at, last_active_at";
@@ -118,4 +146,123 @@ export function getConversation(db: Database, id: string): Conversation | null {
     )
     .get(id);
   return row ? rowToConversation(row) : null;
+}
+
+function isPathClaimed(db: Database, projectId: string, worktreePath: string): boolean {
+  const row = db
+    .prepare<{ id: string }, [string, string]>(
+      "SELECT id FROM conversations WHERE project_id = ? AND worktree_path = ? LIMIT 1",
+    )
+    .get(projectId, worktreePath);
+  return row !== null;
+}
+
+function defaultWorktreePathFor(project: Project, branch: string): string {
+  return resolve(project.worktree_root, branch);
+}
+
+function insertConversation(db: Database, conversation: Conversation): void {
+  db.run(
+    `INSERT INTO conversations (${CONVERSATION_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      conversation.id,
+      conversation.project_id,
+      conversation.worktree_path,
+      conversation.branch,
+      conversation.session_id,
+      conversation.title,
+      conversation.color,
+      conversation.is_default ? 1 : 0,
+      conversation.status,
+      conversation.created_at,
+      conversation.last_active_at,
+    ],
+  );
+}
+
+export async function createConversation(
+  db: Database,
+  project: Project,
+  input: CreateConversationInput,
+): Promise<Conversation> {
+  let worktreePath: string;
+  let branch: string;
+
+  if (input.mode === "main") {
+    worktreePath = project.repo_path;
+    branch = (await detectCurrentBranch(project.repo_path)) ?? project.default_branch;
+    if (isPathClaimed(db, project.id, worktreePath)) {
+      throw new ConversationValidationError(
+        "worktree_in_use",
+        "mode",
+        `Main worktree is already attached to another conversation`,
+      );
+    }
+  } else if (input.mode === "new-worktree" || input.mode === "existing-branch") {
+    const trimmed = (input.branch ?? "").trim();
+    if (trimmed.length === 0) {
+      throw new ConversationValidationError("branch_required", "branch", "Branch is required");
+    }
+    branch = trimmed;
+    worktreePath = defaultWorktreePathFor(project, branch);
+
+    if (isPathClaimed(db, project.id, worktreePath)) {
+      throw new ConversationValidationError(
+        "worktree_in_use",
+        "branch",
+        `A conversation already claims worktree path "${worktreePath}"`,
+      );
+    }
+
+    try {
+      if (input.mode === "new-worktree") {
+        await createWorktree({
+          repoPath: project.repo_path,
+          worktreePath,
+          branch,
+          mode: "new-branch",
+          baseBranch: input.base_branch?.trim() || project.default_branch,
+          isClaimed: (path) => isPathClaimed(db, project.id, path),
+        });
+      } else {
+        await createWorktree({
+          repoPath: project.repo_path,
+          worktreePath,
+          branch,
+          mode: "existing-branch",
+          isClaimed: (path) => isPathClaimed(db, project.id, path),
+        });
+      }
+    } catch (err) {
+      if (err instanceof WorktreeError) {
+        const field = err.code === "missing_base_branch" ? "base_branch" : "branch";
+        throw new ConversationValidationError("worktree_create_failed", field, err.message);
+      }
+      throw err;
+    }
+  } else {
+    throw new ConversationValidationError(
+      "invalid_mode",
+      "mode",
+      `Unknown conversation mode: ${(input as { mode?: string }).mode ?? "(none)"}`,
+    );
+  }
+
+  const now = new Date().toISOString();
+  const conversation: Conversation = {
+    id: randomUUID(),
+    project_id: project.id,
+    worktree_path: worktreePath,
+    branch,
+    session_id: null,
+    title: input.mode === "main" ? project.name : branch,
+    color: null,
+    is_default: false,
+    status: "active",
+    created_at: now,
+    last_active_at: now,
+  };
+
+  insertConversation(db, conversation);
+  return conversation;
 }

--- a/server/worktrees/manager.ts
+++ b/server/worktrees/manager.ts
@@ -1,0 +1,218 @@
+import { resolve } from "node:path";
+import { realpath, stat } from "node:fs/promises";
+import { $ } from "bun";
+
+export type WorktreeErrorCode =
+  | "not_a_repo"
+  | "not_a_worktree"
+  | "path_claimed"
+  | "path_exists"
+  | "branch_already_checked_out"
+  | "branch_already_exists"
+  | "missing_base_branch"
+  | "dirty_worktree"
+  | "git_error";
+
+export class WorktreeError extends Error {
+  readonly code: WorktreeErrorCode;
+  constructor(code: WorktreeErrorCode, message: string) {
+    super(message);
+    this.name = "WorktreeError";
+    this.code = code;
+  }
+}
+
+export type WorktreeEntry = {
+  path: string;
+  branch: string | null;
+  head: string | null;
+  isBare: boolean;
+  isDetached: boolean;
+};
+
+export type CreateMode = "new-branch" | "existing-branch";
+
+export type CreateWorktreeOptions = {
+  repoPath: string;
+  worktreePath: string;
+  branch: string;
+  mode: CreateMode;
+  baseBranch?: string;
+  isClaimed?: (path: string) => boolean;
+};
+
+export type RemoveWorktreeOptions = {
+  force?: boolean;
+};
+
+async function pathExists(path: string): Promise<boolean> {
+  return (await stat(path).catch(() => null)) !== null;
+}
+
+async function canonicalize(path: string): Promise<string> {
+  const absolute = resolve(path);
+  return (await realpath(absolute).catch(() => null)) ?? absolute;
+}
+
+export function parseWorktreeListPorcelain(text: string): WorktreeEntry[] {
+  const entries: WorktreeEntry[] = [];
+  let current: Partial<WorktreeEntry> | null = null;
+
+  const finalize = () => {
+    if (current?.path) {
+      entries.push({
+        path: current.path,
+        branch: current.branch ?? null,
+        head: current.head ?? null,
+        isBare: current.isBare ?? false,
+        isDetached: current.isDetached ?? false,
+      });
+    }
+    current = null;
+  };
+
+  for (const line of text.split("\n")) {
+    if (line.length === 0) {
+      finalize();
+      continue;
+    }
+    if (!current) current = {};
+    const space = line.indexOf(" ");
+    const key = space === -1 ? line : line.slice(0, space);
+    const value = space === -1 ? "" : line.slice(space + 1);
+    if (key === "worktree") current.path = value;
+    else if (key === "HEAD") current.head = value;
+    else if (key === "branch") current.branch = value.replace(/^refs\/heads\//, "");
+    else if (key === "bare") current.isBare = true;
+    else if (key === "detached") current.isDetached = true;
+  }
+  finalize();
+  return entries;
+}
+
+export async function listWorktrees(repoPath: string): Promise<WorktreeEntry[]> {
+  const result = await $`git -C ${repoPath} worktree list --porcelain`.quiet().nothrow();
+  if (result.exitCode !== 0) {
+    throw new WorktreeError("not_a_repo", `Not a git repository: ${repoPath}`);
+  }
+  return parseWorktreeListPorcelain(result.stdout.toString());
+}
+
+export async function worktreeExists(repoPath: string, worktreePath: string): Promise<boolean> {
+  const target = await canonicalize(worktreePath);
+  const list = await listWorktrees(repoPath);
+  for (const entry of list) {
+    if ((await canonicalize(entry.path)) === target) return true;
+  }
+  return false;
+}
+
+export async function isWorktreeDirty(worktreePath: string): Promise<boolean> {
+  const result = await $`git -C ${worktreePath} status --porcelain`.quiet().nothrow();
+  if (result.exitCode !== 0) {
+    throw new WorktreeError("not_a_repo", `Not a git working tree: ${worktreePath}`);
+  }
+  return result.stdout.toString().trim().length > 0;
+}
+
+async function branchExists(repoPath: string, branch: string): Promise<boolean> {
+  const ref = `refs/heads/${branch}`;
+  const result = await $`git -C ${repoPath} show-ref --verify --quiet ${ref}`.quiet().nothrow();
+  return result.exitCode === 0;
+}
+
+export async function createWorktree(opts: CreateWorktreeOptions): Promise<WorktreeEntry> {
+  const target = resolve(opts.worktreePath);
+
+  if (opts.isClaimed?.(target)) {
+    throw new WorktreeError("path_claimed", `Worktree path is already claimed: ${target}`);
+  }
+
+  if (await pathExists(target)) {
+    throw new WorktreeError("path_exists", `A file or directory already exists at ${target}`);
+  }
+
+  if (opts.mode === "new-branch") {
+    const base = opts.baseBranch?.trim() ?? "";
+    if (base.length === 0) {
+      throw new WorktreeError("missing_base_branch", "Base branch is required for new-branch mode");
+    }
+    if (!(await branchExists(opts.repoPath, base))) {
+      throw new WorktreeError("missing_base_branch", `Base branch "${base}" does not exist`);
+    }
+    if (await branchExists(opts.repoPath, opts.branch)) {
+      throw new WorktreeError(
+        "branch_already_exists",
+        `Branch "${opts.branch}" already exists; use existing-branch mode to attach`,
+      );
+    }
+    const result = await $`git -C ${opts.repoPath} worktree add -b ${opts.branch} ${target} ${base}`
+      .quiet()
+      .nothrow();
+    if (result.exitCode !== 0) {
+      throw new WorktreeError(
+        "git_error",
+        result.stderr.toString().trim() || "git worktree add failed",
+      );
+    }
+  } else {
+    if (!(await branchExists(opts.repoPath, opts.branch))) {
+      throw new WorktreeError("git_error", `Branch "${opts.branch}" does not exist`);
+    }
+    const result = await $`git -C ${opts.repoPath} worktree add ${target} ${opts.branch}`
+      .quiet()
+      .nothrow();
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.toString();
+      if (/is already checked out|is already used/i.test(stderr)) {
+        throw new WorktreeError(
+          "branch_already_checked_out",
+          `Branch "${opts.branch}" is already checked out elsewhere`,
+        );
+      }
+      throw new WorktreeError("git_error", stderr.trim() || "git worktree add failed");
+    }
+  }
+
+  const canonicalTarget = await canonicalize(target);
+  const entries = await listWorktrees(opts.repoPath);
+  let created: WorktreeEntry | null = null;
+  for (const entry of entries) {
+    if ((await canonicalize(entry.path)) === canonicalTarget) {
+      created = entry;
+      break;
+    }
+  }
+  if (!created) {
+    throw new WorktreeError(
+      "git_error",
+      "Worktree did not appear in git worktree list after creation",
+    );
+  }
+  return created;
+}
+
+export async function removeWorktree(
+  repoPath: string,
+  worktreePath: string,
+  opts: RemoveWorktreeOptions = {},
+): Promise<void> {
+  const target = resolve(worktreePath);
+  if (!(await worktreeExists(repoPath, target))) {
+    throw new WorktreeError("not_a_worktree", `Not a registered worktree: ${target}`);
+  }
+  if (!opts.force) {
+    if (await isWorktreeDirty(target)) {
+      throw new WorktreeError("dirty_worktree", `Worktree has uncommitted changes: ${target}`);
+    }
+  }
+  const result = opts.force
+    ? await $`git -C ${repoPath} worktree remove --force ${target}`.quiet().nothrow()
+    : await $`git -C ${repoPath} worktree remove ${target}`.quiet().nothrow();
+  if (result.exitCode !== 0) {
+    throw new WorktreeError(
+      "git_error",
+      result.stderr.toString().trim() || "git worktree remove failed",
+    );
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -92,6 +92,23 @@ export async function listConversations(projectId: string): Promise<Conversation
   return data.conversations;
 }
 
+export type CreateConversationInput =
+  | { mode: "main" }
+  | { mode: "new-worktree"; branch: string; base_branch?: string }
+  | { mode: "existing-branch"; branch: string };
+
+export async function createConversation(
+  projectId: string,
+  input: CreateConversationInput,
+): Promise<Conversation> {
+  const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/conversations`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return unwrap<Conversation>(res);
+}
+
 export type AssistantBlock =
   | { type: "text"; text: string }
   | { type: "thinking"; text: string }

--- a/src/routes/projects.$projectId.tsx
+++ b/src/routes/projects.$projectId.tsx
@@ -1,13 +1,15 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
-import { ChevronLeft, GitBranch, MessagesSquare, Pin } from "lucide-react";
+import { ChevronLeft, GitBranch, MessagesSquare, Pin, Plus, X } from "lucide-react";
 import { cn } from "../lib/cn";
 import { formatRelativeTime } from "../lib/time";
 import {
   ApiRequestError,
+  createConversation,
   getProject,
   listConversations,
   type Conversation,
+  type CreateConversationInput,
   type Project,
 } from "../lib/api";
 
@@ -76,7 +78,17 @@ function ProjectDetailRoute() {
       )}
 
       {state.kind === "ok" && (
-        <ProjectDetail project={state.project} conversations={state.conversations} />
+        <ProjectDetail
+          project={state.project}
+          conversations={state.conversations}
+          onConversationCreated={(conversation) =>
+            setState({
+              kind: "ok",
+              project: state.project,
+              conversations: [...state.conversations, conversation],
+            })
+          }
+        />
       )}
     </main>
   );
@@ -85,10 +97,14 @@ function ProjectDetailRoute() {
 function ProjectDetail({
   project,
   conversations,
+  onConversationCreated,
 }: {
   project: Project;
   conversations: Conversation[];
+  onConversationCreated: (conversation: Conversation) => void;
 }) {
+  const [showForm, setShowForm] = useState(false);
+
   return (
     <>
       <header className="mb-6">
@@ -106,7 +122,38 @@ function ProjectDetail({
       </header>
 
       <section>
-        <h2 className="mb-3 text-sm font-medium text-muted-foreground">Conversations</h2>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-sm font-medium text-muted-foreground">Conversations</h2>
+          <button
+            type="button"
+            onClick={() => setShowForm((v) => !v)}
+            className={cn(
+              "inline-flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-medium transition",
+              showForm
+                ? "bg-muted text-foreground hover:bg-accent"
+                : "bg-primary text-primary-foreground hover:opacity-90",
+            )}
+          >
+            {showForm ? (
+              <X className="size-4" aria-hidden />
+            ) : (
+              <Plus className="size-4" aria-hidden />
+            )}
+            <span>{showForm ? "Cancel" : "New"}</span>
+          </button>
+        </div>
+
+        {showForm && (
+          <NewConversationForm
+            project={project}
+            existingPaths={new Set(conversations.map((c) => c.worktree_path))}
+            onCreated={(conversation) => {
+              onConversationCreated(conversation);
+              setShowForm(false);
+            }}
+          />
+        )}
+
         {conversations.length === 0 ? (
           <ConversationsEmpty />
         ) : (
@@ -118,6 +165,198 @@ function ProjectDetail({
         )}
       </section>
     </>
+  );
+}
+
+type NewConversationMode = "main" | "new-worktree" | "existing-branch";
+type NewConversationErrors = { branch?: string; base_branch?: string; form?: string };
+
+function NewConversationForm({
+  project,
+  existingPaths,
+  onCreated,
+}: {
+  project: Project;
+  existingPaths: Set<string>;
+  onCreated: (conversation: Conversation) => void;
+}) {
+  const [mode, setMode] = useState<NewConversationMode>("new-worktree");
+  const [branch, setBranch] = useState("");
+  const [baseBranch, setBaseBranch] = useState("");
+  const [errors, setErrors] = useState<NewConversationErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const mainAlreadyClaimed = existingPaths.has(project.repo_path);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrors({});
+    setSubmitting(true);
+    try {
+      const input: CreateConversationInput =
+        mode === "main"
+          ? { mode }
+          : mode === "new-worktree"
+            ? {
+                mode,
+                branch,
+                ...(baseBranch.trim() ? { base_branch: baseBranch.trim() } : {}),
+              }
+            : { mode, branch };
+      const conversation = await createConversation(project.id, input);
+      onCreated(conversation);
+      setBranch("");
+      setBaseBranch("");
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        const field = err.body.field;
+        if (field === "branch" || field === "base_branch") {
+          setErrors({ [field]: err.body.message });
+        } else {
+          setErrors({ form: err.body.message });
+        }
+      } else {
+        setErrors({ form: err instanceof Error ? err.message : "Create failed" });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="mb-6 flex flex-col gap-4 rounded-2xl border border-border/60 bg-card p-5"
+    >
+      <fieldset className="flex flex-col gap-2">
+        <legend className="mb-1 text-sm font-medium">Mode</legend>
+        <ModeOption
+          checked={mode === "main"}
+          onChange={() => setMode("main")}
+          label="Attach to main worktree"
+          description={
+            mainAlreadyClaimed
+              ? "Already attached to another conversation."
+              : "Use the project's main checkout."
+          }
+          disabled={mainAlreadyClaimed}
+        />
+        <ModeOption
+          checked={mode === "new-worktree"}
+          onChange={() => setMode("new-worktree")}
+          label="Create new worktree on a new branch"
+          description="Branches off a base branch into a fresh worktree directory."
+        />
+        <ModeOption
+          checked={mode === "existing-branch"}
+          onChange={() => setMode("existing-branch")}
+          label="Attach to existing branch"
+          description="Adds a worktree that checks out a branch that already exists."
+        />
+      </fieldset>
+
+      {mode !== "main" && (
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="conversation-branch" className="text-sm font-medium">
+            Branch
+          </label>
+          <input
+            id="conversation-branch"
+            value={branch}
+            onChange={(e) => setBranch(e.target.value)}
+            placeholder={mode === "new-worktree" ? "feature/my-thing" : "existing-branch"}
+            autoComplete="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            className={cn(inputClass(!!errors.branch), "font-mono text-sm")}
+          />
+          {errors.branch && <p className="text-xs text-destructive">{errors.branch}</p>}
+        </div>
+      )}
+
+      {mode === "new-worktree" && (
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="conversation-base-branch" className="text-sm font-medium">
+            Base branch <span className="text-muted-foreground">(optional)</span>
+          </label>
+          <input
+            id="conversation-base-branch"
+            value={baseBranch}
+            onChange={(e) => setBaseBranch(e.target.value)}
+            placeholder={project.default_branch}
+            autoComplete="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            className={cn(inputClass(!!errors.base_branch), "font-mono text-sm")}
+          />
+          {errors.base_branch && <p className="text-xs text-destructive">{errors.base_branch}</p>}
+          <p className="text-xs text-muted-foreground">
+            Defaults to <span className="font-mono">{project.default_branch}</span>.
+          </p>
+        </div>
+      )}
+
+      {errors.form && (
+        <p className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {errors.form}
+        </p>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={submitting || (mode === "main" && mainAlreadyClaimed)}
+          className="inline-flex h-10 items-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? "Creating…" : "Create conversation"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function ModeOption({
+  checked,
+  onChange,
+  label,
+  description,
+  disabled,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  description: string;
+  disabled?: boolean;
+}) {
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer items-start gap-3 rounded-lg border bg-background p-3 transition",
+        checked ? "border-primary/60" : "border-border/60 hover:border-border",
+        disabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      <input
+        type="radio"
+        name="conversation-mode"
+        className="mt-1"
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+      />
+      <span className="flex-1">
+        <span className="block text-sm font-medium">{label}</span>
+        <span className="mt-0.5 block text-xs text-muted-foreground">{description}</span>
+      </span>
+    </label>
+  );
+}
+
+function inputClass(hasError: boolean): string {
+  return cn(
+    "h-10 w-full rounded-lg border bg-background px-3 text-sm outline-none transition",
+    "border-input focus:border-ring focus:ring-2 focus:ring-ring/30",
+    hasError && "border-destructive focus:border-destructive focus:ring-destructive/30",
   );
 }
 

--- a/tests/conversations-registry.test.ts
+++ b/tests/conversations-registry.test.ts
@@ -8,6 +8,8 @@ import { $ } from "bun";
 import { runMigrationsFromDir } from "../server/db/migrator.ts";
 import { registerProject } from "../server/projects/registry.ts";
 import {
+  ConversationValidationError,
+  createConversation,
   ensureDefaultConversation,
   getConversation,
   listConversations,
@@ -132,5 +134,113 @@ describe("Conversations Registry", () => {
 
     expect(getConversation(db, created.id)?.id).toBe(created.id);
     expect(getConversation(db, "nope")).toBeNull();
+  });
+});
+
+describe("createConversation", () => {
+  test("new-worktree mode creates a worktree and a conversation row off the default branch", async () => {
+    const project = await makeProject("WT");
+    await ensureDefaultConversation(db, project);
+
+    const conversation = await createConversation(db, project, {
+      mode: "new-worktree",
+      branch: "feature/x",
+    });
+
+    expect(conversation.is_default).toBe(false);
+    expect(conversation.branch).toBe("feature/x");
+    expect(conversation.title).toBe("feature/x");
+    expect(conversation.worktree_path).toBe(`${project.worktree_root}/feature/x`);
+
+    const stored = getConversation(db, conversation.id);
+    expect(stored?.id).toBe(conversation.id);
+  });
+
+  test("new-worktree mode honors an explicit base_branch", async () => {
+    const project = await makeProject("Base");
+    await $`git -C ${project.repo_path} checkout -b release`.quiet();
+    await $`git -C ${project.repo_path} checkout main`.quiet();
+
+    const conversation = await createConversation(db, project, {
+      mode: "new-worktree",
+      branch: "fix/bug",
+      base_branch: "release",
+    });
+
+    expect(conversation.branch).toBe("fix/bug");
+  });
+
+  test("existing-branch mode attaches a worktree to a branch that already exists", async () => {
+    const project = await makeProject("Existing");
+    await $`git -C ${project.repo_path} branch other`.quiet();
+
+    const conversation = await createConversation(db, project, {
+      mode: "existing-branch",
+      branch: "other",
+    });
+
+    expect(conversation.branch).toBe("other");
+    expect(conversation.worktree_path).toBe(`${project.worktree_root}/other`);
+  });
+
+  test("existing-branch mode rejects a branch that does not exist", async () => {
+    const project = await makeProject("Missing");
+    let thrown: unknown;
+    try {
+      await createConversation(db, project, {
+        mode: "existing-branch",
+        branch: "ghost",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ConversationValidationError);
+    expect((thrown as ConversationValidationError).code).toBe("worktree_create_failed");
+  });
+
+  test("rejects creating a second conversation that would claim the same worktree path", async () => {
+    const project = await makeProject("Dup");
+    await createConversation(db, project, { mode: "new-worktree", branch: "feat" });
+
+    await expect(
+      createConversation(db, project, { mode: "new-worktree", branch: "feat" }),
+    ).rejects.toMatchObject({ code: "worktree_in_use" });
+  });
+
+  test("requires a branch for new-worktree and existing-branch modes", async () => {
+    const project = await makeProject("NoBranch");
+    await expect(
+      createConversation(db, project, { mode: "new-worktree", branch: "" }),
+    ).rejects.toMatchObject({ code: "branch_required", field: "branch" });
+    await expect(
+      createConversation(db, project, { mode: "existing-branch", branch: "   " }),
+    ).rejects.toMatchObject({ code: "branch_required", field: "branch" });
+  });
+
+  test("main mode reuses the project repo path and rejects when already claimed", async () => {
+    const project = await makeProject("MainMode");
+    await ensureDefaultConversation(db, project);
+
+    await expect(createConversation(db, project, { mode: "main" })).rejects.toMatchObject({
+      code: "worktree_in_use",
+    });
+  });
+
+  test("main mode succeeds when no default conversation has been seeded", async () => {
+    const project = await makeProject("MainSolo");
+    const conversation = await createConversation(db, project, { mode: "main" });
+    expect(conversation.worktree_path).toBe(project.repo_path);
+    expect(conversation.is_default).toBe(false);
+  });
+
+  test("missing base_branch surfaces a clear validation error", async () => {
+    const project = await makeProject("BadBase");
+    await expect(
+      createConversation(db, project, {
+        mode: "new-worktree",
+        branch: "feat",
+        base_branch: "no-such-branch",
+      }),
+    ).rejects.toMatchObject({ code: "worktree_create_failed", field: "base_branch" });
   });
 });

--- a/tests/worktree-manager.test.ts
+++ b/tests/worktree-manager.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+import {
+  createWorktree,
+  isWorktreeDirty,
+  listWorktrees,
+  parseWorktreeListPorcelain,
+  removeWorktree,
+  WorktreeError,
+  worktreeExists,
+} from "../server/worktrees/manager.ts";
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "claude-remote-worktree-"));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function initRepo(path: string, initialBranch = "main") {
+  mkdirSync(path, { recursive: true });
+  await $`git -C ${path} init -b ${initialBranch}`.quiet();
+  await $`git -C ${path} config user.email test@example.com`.quiet();
+  await $`git -C ${path} config user.name Test`.quiet();
+  writeFileSync(join(path, "README.md"), "test\n");
+  await $`git -C ${path} add .`.quiet();
+  await $`git -C ${path} commit -m initial`.quiet();
+}
+
+describe("parseWorktreeListPorcelain", () => {
+  test("parses a single main worktree entry", () => {
+    const text = "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n";
+    const entries = parseWorktreeListPorcelain(text);
+    expect(entries).toEqual([
+      { path: "/repo", branch: "main", head: "abc123", isBare: false, isDetached: false },
+    ]);
+  });
+
+  test("parses multiple entries separated by blank lines", () => {
+    const text =
+      "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n" +
+      "worktree /repo/.worktrees/feat\nHEAD def456\nbranch refs/heads/feat\n\n";
+    const entries = parseWorktreeListPorcelain(text);
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toMatchObject({ path: "/repo/.worktrees/feat", branch: "feat" });
+  });
+
+  test("captures bare and detached flags", () => {
+    const text = "worktree /bare\nbare\n\nworktree /detached\nHEAD abc\ndetached\n";
+    const entries = parseWorktreeListPorcelain(text);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ path: "/bare", isBare: true, branch: null });
+    expect(entries[1]).toMatchObject({ path: "/detached", isDetached: true, branch: null });
+  });
+});
+
+describe("listWorktrees", () => {
+  test("returns the main worktree on a fresh repo", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const entries = await listWorktrees(repo);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ branch: "main", isBare: false, isDetached: false });
+  });
+
+  test("throws not_a_repo when the path is not a git repo", async () => {
+    const plain = join(tempDir, "plain");
+    mkdirSync(plain);
+    let thrown: unknown;
+    try {
+      await listWorktrees(plain);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(WorktreeError);
+    expect((thrown as WorktreeError).code).toBe("not_a_repo");
+  });
+});
+
+describe("createWorktree (new-branch)", () => {
+  test("creates a worktree on a new branch off the base branch", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const target = join(tempDir, "wt", "feature-x");
+
+    const entry = await createWorktree({
+      repoPath: repo,
+      worktreePath: target,
+      branch: "feature/x",
+      mode: "new-branch",
+      baseBranch: "main",
+    });
+
+    expect(entry.branch).toBe("feature/x");
+    expect(await worktreeExists(repo, target)).toBe(true);
+  });
+
+  test("throws missing_base_branch when base branch is missing or absent", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const target = join(tempDir, "wt", "feat");
+
+    await expect(
+      createWorktree({
+        repoPath: repo,
+        worktreePath: target,
+        branch: "feat",
+        mode: "new-branch",
+        baseBranch: "",
+      }),
+    ).rejects.toMatchObject({ code: "missing_base_branch" });
+
+    await expect(
+      createWorktree({
+        repoPath: repo,
+        worktreePath: target,
+        branch: "feat",
+        mode: "new-branch",
+        baseBranch: "no-such-branch",
+      }),
+    ).rejects.toMatchObject({ code: "missing_base_branch" });
+  });
+
+  test("throws branch_already_exists when the new branch name is already taken", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    await $`git -C ${repo} branch existing`.quiet();
+
+    await expect(
+      createWorktree({
+        repoPath: repo,
+        worktreePath: join(tempDir, "wt", "existing"),
+        branch: "existing",
+        mode: "new-branch",
+        baseBranch: "main",
+      }),
+    ).rejects.toMatchObject({ code: "branch_already_exists" });
+  });
+});
+
+describe("createWorktree (existing-branch)", () => {
+  test("creates a worktree that checks out an existing branch", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    await $`git -C ${repo} branch other`.quiet();
+    const target = join(tempDir, "wt", "other");
+
+    const entry = await createWorktree({
+      repoPath: repo,
+      worktreePath: target,
+      branch: "other",
+      mode: "existing-branch",
+    });
+
+    expect(entry.branch).toBe("other");
+  });
+
+  test("throws branch_already_checked_out when the branch is checked out elsewhere", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    await expect(
+      createWorktree({
+        repoPath: repo,
+        worktreePath: join(tempDir, "wt", "main"),
+        branch: "main",
+        mode: "existing-branch",
+      }),
+    ).rejects.toMatchObject({ code: "branch_already_checked_out" });
+  });
+
+  test("throws git_error when the branch does not exist", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    await expect(
+      createWorktree({
+        repoPath: repo,
+        worktreePath: join(tempDir, "wt", "nope"),
+        branch: "no-such-branch",
+        mode: "existing-branch",
+      }),
+    ).rejects.toBeInstanceOf(WorktreeError);
+  });
+});
+
+describe("createWorktree (claims and path collisions)", () => {
+  test("throws path_claimed when isClaimed returns true", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    await expect(
+      createWorktree({
+        repoPath: repo,
+        worktreePath: join(tempDir, "wt", "feat"),
+        branch: "feat",
+        mode: "new-branch",
+        baseBranch: "main",
+        isClaimed: () => true,
+      }),
+    ).rejects.toMatchObject({ code: "path_claimed" });
+  });
+
+  test("throws path_exists when the target path already exists", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const target = join(tempDir, "occupied");
+    mkdirSync(target);
+    await expect(
+      createWorktree({
+        repoPath: repo,
+        worktreePath: target,
+        branch: "feat",
+        mode: "new-branch",
+        baseBranch: "main",
+      }),
+    ).rejects.toMatchObject({ code: "path_exists" });
+  });
+});
+
+describe("removeWorktree", () => {
+  test("removes a clean worktree", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const target = join(tempDir, "wt", "feat");
+    await createWorktree({
+      repoPath: repo,
+      worktreePath: target,
+      branch: "feat",
+      mode: "new-branch",
+      baseBranch: "main",
+    });
+
+    await removeWorktree(repo, target);
+    expect(await worktreeExists(repo, target)).toBe(false);
+  });
+
+  test("refuses to remove a dirty worktree without force", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const target = join(tempDir, "wt", "feat");
+    await createWorktree({
+      repoPath: repo,
+      worktreePath: target,
+      branch: "feat",
+      mode: "new-branch",
+      baseBranch: "main",
+    });
+    writeFileSync(join(target, "dirty.txt"), "hello\n");
+
+    await expect(removeWorktree(repo, target)).rejects.toMatchObject({
+      code: "dirty_worktree",
+    });
+    expect(await worktreeExists(repo, target)).toBe(true);
+  });
+
+  test("removes a dirty worktree when force is set", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const target = join(tempDir, "wt", "feat");
+    await createWorktree({
+      repoPath: repo,
+      worktreePath: target,
+      branch: "feat",
+      mode: "new-branch",
+      baseBranch: "main",
+    });
+    writeFileSync(join(target, "dirty.txt"), "hello\n");
+
+    await removeWorktree(repo, target, { force: true });
+    expect(await worktreeExists(repo, target)).toBe(false);
+  });
+
+  test("throws not_a_worktree when the path is not a registered worktree", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    const stranger = join(tempDir, "stranger");
+    mkdirSync(stranger);
+    await expect(removeWorktree(repo, stranger)).rejects.toMatchObject({
+      code: "not_a_worktree",
+    });
+  });
+});
+
+describe("isWorktreeDirty", () => {
+  test("returns false for a clean worktree", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    expect(await isWorktreeDirty(repo)).toBe(false);
+  });
+
+  test("returns true after an untracked file is added", async () => {
+    const repo = join(tempDir, "repo");
+    await initRepo(repo);
+    writeFileSync(join(repo, "new.txt"), "hi\n");
+    expect(await isWorktreeDirty(repo)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #6.

## Summary
- New `server/worktrees/manager.ts` wraps `git worktree` with `create` / `list` / `remove` / `exists` / `isDirty`, a porcelain parser, and a typed `WorktreeError` (codes for `not_a_repo`, `not_a_worktree`, `path_claimed`, `path_exists`, `branch_already_checked_out`, `branch_already_exists`, `missing_base_branch`, `dirty_worktree`, `git_error`).
- `createConversation` in the conversations registry orchestrates the three modes (`main`, `new-worktree`, `existing-branch`); rejects path collisions both up front (DB check) and via `isClaimed` passed into the manager. Default worktree path is `<repo_parent>/.worktrees/<repo>/<branch>` (read from `project.worktree_root`, which stays per-project configurable).
- `POST /api/projects/:id/conversations` accepts `{ mode, branch?, base_branch? }` and returns the new row (201 / 400 / 404 / 409). Session Manager already enforces worktree exclusivity from slice 4; `worktree_in_use` now also surfaces from create.
- Web: `createConversation()` client + a New conversation form on the project detail page with the three modes. The "main" option auto-disables when the path is already claimed.

## Test plan
- [x] `bun run test` — 79 tests across 7 files, including 19 new worktree-manager tests against real temp git repos and 9 new createConversation tests
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] End-to-end smoke test against a real repo: new-worktree creates `<wt_root>/<branch>`, missing branch returns `worktree_create_failed`, duplicate POST returns `worktree_in_use`
- [ ] Open the New conversation form in the browser and confirm the three modes work and disabled "main" state renders when default already claims the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)