### PR TITLE
fix: chat sends now deliver — WS proxy bypass, SDK init deadlock, optimistic bubble

### DIFF
--- a/server/sessions/manager.ts
+++ b/server/sessions/manager.ts
@@ -1,7 +1,13 @@
 import type { Database } from "bun:sqlite";
 import type { AssistantBlock } from "../transcript/reader.ts";
 import { InputStream } from "./input-stream.ts";
-import type { Listener, SessionEvent, SpawnedSDKMessage, Spawner } from "./types.ts";
+import type {
+  Listener,
+  SessionEvent,
+  SpawnedSDKMessage,
+  Spawner,
+  SpawnInputMessage,
+} from "./types.ts";
 
 export class SessionStartError extends Error {
   readonly code: string;
@@ -105,7 +111,10 @@ export class SessionManager {
     return [...(this.buffered.get(conversationId) ?? [])];
   }
 
-  async start(conversationId: string): Promise<SessionInfo> {
+  async start(
+    conversationId: string,
+    options: { firstInput?: SpawnInputMessage } = {},
+  ): Promise<SessionInfo> {
     const inflight = this.inflight.get(conversationId);
     if (inflight) return inflight;
 
@@ -129,7 +138,7 @@ export class SessionManager {
       this.db.run("DELETE FROM session_ledger WHERE conversation_id = ?", [conversationId]);
     }
 
-    const promise = this.doSpawn(conversationId);
+    const promise = this.doSpawn(conversationId, options.firstInput);
     this.inflight.set(conversationId, promise);
     try {
       return await promise;
@@ -139,18 +148,31 @@ export class SessionManager {
   }
 
   async send(conversationId: string, text: string): Promise<void> {
-    const session = this.active.get(conversationId) ?? null;
-    if (!session) {
-      await this.start(conversationId);
-    }
-    const active = this.active.get(conversationId);
-    if (!active) {
-      throw new SessionStartError("not_started", "Session is not running");
-    }
-    active.input.push({
+    const message: SpawnInputMessage = {
       type: "user",
       message: { role: "user", content: text },
-    });
+    };
+
+    const active = this.active.get(conversationId);
+    if (active && this.isPidAlive(active.host_pid)) {
+      active.input.push(message);
+      return;
+    }
+
+    // Concurrent send raced ahead of us — wait for that spawn, then push.
+    const inflight = this.inflight.get(conversationId);
+    if (inflight) {
+      await inflight;
+      const ready = this.active.get(conversationId);
+      if (!ready) throw new SessionStartError("not_started", "Session is not running");
+      ready.input.push(message);
+      return;
+    }
+
+    // First send for this conversation. Pre-buffer the user's text so the SDK
+    // has input on its first read — without it, the SDK never emits the init
+    // message we await on start, and we deadlock.
+    await this.start(conversationId, { firstInput: message });
   }
 
   async stop(conversationId: string): Promise<void> {
@@ -161,7 +183,10 @@ export class SessionManager {
     this.cleanup(conversationId, "stopped");
   }
 
-  private async doSpawn(conversationId: string): Promise<SessionInfo> {
+  private async doSpawn(
+    conversationId: string,
+    firstInput?: SpawnInputMessage,
+  ): Promise<SessionInfo> {
     const conversation = this.db
       .prepare<ConversationRow, [string]>(
         "SELECT id, worktree_path FROM conversations WHERE id = ?",
@@ -200,6 +225,7 @@ export class SessionManager {
     }
 
     const input = new InputStream();
+    if (firstInput) input.push(firstInput);
     const result = this.spawner({ cwd: conversation.worktree_path, input });
 
     const initState: {

--- a/src/lib/conversation-ws.ts
+++ b/src/lib/conversation-ws.ts
@@ -34,6 +34,18 @@ export type ConversationWs = {
 const INITIAL_BACKOFF_MS = 250;
 const MAX_BACKOFF_MS = 5_000;
 
+function buildWsUrl(conversationId: string): string {
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const path = `/api/conversations/${encodeURIComponent(conversationId)}/ws`;
+  // Vite's HTTP proxy hangs on WebSocket upgrades, so in dev we hit the API port
+  // directly. In prod the API and the static frontend are served from the same origin.
+  if (import.meta.env.DEV) {
+    const apiPort = import.meta.env.VITE_API_PORT ?? "2634";
+    return `${protocol}//${window.location.hostname}:${apiPort}${path}`;
+  }
+  return `${protocol}//${window.location.host}${path}`;
+}
+
 export function connectConversationWs(
   conversationId: string,
   handlers: ConversationWsHandlers,
@@ -46,11 +58,7 @@ export function connectConversationWs(
   const open = (): void => {
     if (closedByUser) return;
     handlers.onState("connecting");
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const url = `${protocol}//${window.location.host}/api/conversations/${encodeURIComponent(
-      conversationId,
-    )}/ws`;
-    const ws = new WebSocket(url);
+    const ws = new WebSocket(buildWsUrl(conversationId));
     socket = ws;
 
     ws.addEventListener("open", () => {

--- a/src/routes/conversations.$conversationId.tsx
+++ b/src/routes/conversations.$conversationId.tsx
@@ -115,6 +115,14 @@ function ConversationRoute() {
     setErrorBanner(null);
     try {
       await sendConversationMessage(conversationId, text);
+      const optimistic: TranscriptMessage = {
+        kind: "user_message",
+        uuid: `local-${crypto.randomUUID()}`,
+        ts: new Date().toISOString(),
+        text,
+      };
+      seenUuids.current.add(optimistic.uuid);
+      setMessages((prev) => [...prev, optimistic]);
       setDraft("");
     } catch (err) {
       const message = err instanceof Error ? err.message : "Send failed";

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -381,6 +381,72 @@ describe("SessionManager", () => {
     }
   });
 
+  test("send pre-buffers the user's text so the SDK has input before init", async () => {
+    const conversation = await makeConversation("send-firstinput");
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: () => true,
+      hostPid: 1000,
+    });
+
+    // No prior start. send() must spawn AND deliver the text without waiting on
+    // anything from outside (the real SDK won't emit init until input arrives).
+    const sendPromise = manager.send(conversation.id, "first message");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const consumed: { type: string; content: unknown }[] = [];
+    void (async () => {
+      for await (const msg of tracker.latest().options.input) {
+        consumed.push({ type: msg.type, content: msg.message.content });
+      }
+    })();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consumed[0]).toEqual({ type: "user", content: "first message" });
+
+    // Now the SDK can emit init in response to the buffered input.
+    tracker.latest().emit(initMessage("sdk-firstinput"));
+    await sendPromise;
+  });
+
+  test("concurrent sends from a cold start each deliver their text", async () => {
+    const conversation = await makeConversation("send-concurrent");
+    const tracker = new SpawnerTracker();
+    const manager = new SessionManager({
+      db,
+      spawner: tracker.spawner,
+      isPidAlive: () => true,
+      hostPid: 1000,
+    });
+
+    const a = manager.send(conversation.id, "alpha");
+    const b = manager.send(conversation.id, "beta");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(tracker.spawns).toHaveLength(1);
+
+    const consumed: unknown[] = [];
+    void (async () => {
+      for await (const msg of tracker.latest().options.input) {
+        consumed.push(msg.message.content);
+      }
+    })();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    tracker.latest().emit(initMessage("sdk-conc-send"));
+    await Promise.all([a, b]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consumed).toEqual(["alpha", "beta"]);
+  });
+
   test("stop closes input, aborts spawn, deletes ledger row, emits session_end", async () => {
     const conversation = await makeConversation("stop");
     const tracker = new SpawnerTracker();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ const apiPort = Number(process.env.API_PORT ?? 2634);
 
 export default defineConfig({
   resolve: { tsconfigPaths: true },
+  define: {
+    "import.meta.env.VITE_API_PORT": JSON.stringify(String(apiPort)),
+  },
   server: {
     port,
     host: process.env.HOST ?? "127.0.0.1",


### PR DESCRIPTION
Three latent bugs that together made the chat appear to hang. None are slice-5-specific; they were exposed once a real send was attempted against the running SDK.

## Summary

1. **Vite WS proxy hang.** Vite at port 2633 accepted the TCP connection for `/api/conversations/:id/ws` but never forwarded the upgrade to Bun, so the browser's `open` event never fired and the UI stayed in "connecting". A direct curl to bun returns `101 Switching Protocols` in <1ms; through vite it timed out at 3s. In dev, the client now connects directly to `ws://<host>:<API_PORT>/api/...`. Prod (same origin) is unchanged.
2. **SDK init deadlock.** `SessionManager.send()` awaited init before pushing user input — but the Anthropic SDK doesn't emit init until it has received input. Every first send for a conversation deadlocked, and the orphaned `claude` subprocess sat alive waiting on stdin (verified live: 5+ minute hung children). Fix: `send()` now pre-buffers the user's text into the input stream before the spawner iterates. Concurrent sends serialize through the inflight start and push their text after.
3. **No optimistic user bubble.** The SDK only echoes assistant + tool messages, so the user's own text never came back via the WS. After sending, the composer cleared but no bubble appeared. Now the conversation route appends a local `user_message` immediately on successful POST.

## Test plan
- [x] `bun run test` (81 tests across 7 files; 2 new in session-manager.test.ts: pre-buffered first send, concurrent cold-start sends)
- [x] `bun run typecheck`
- [x] `bun run lint` / `bun run format:check`
- [x] Live: POST `/api/conversations/:id/messages` to the running dev API now returns 202 in ~1.2s; assistant reply streams back via WS in ~1ms after init
- [ ] Open the conversation page in the browser, send a message, see the user bubble + assistant reply

## Notes
- After pulling this, restart `bun run dev` once — the `VITE_API_PORT` `define` is baked at vite startup.
- If you have orphaned `claude --output-format stream-json` subprocesses from before this fix, kill them: `pkill -f 'claude --output-format stream-json'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)